### PR TITLE
0.2.0 prep work - refactor io, play with benchmarks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: gh.build
 on: [push]
 jobs:
-  beta:
+  beta-sync:
     runs-on: ubuntu-latest
     services:
       redis:
@@ -15,14 +15,14 @@ jobs:
         run: rustup toolchain install beta
       - name: use-beta
         run: rustup default beta
-      - name: build
+      - name: build-sync
         run: cargo build
-      - name: test
-        run: cargo test --features kramer-async
+      - name: test-sync
+        run: cargo test
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
-  nightly-async:
+  beta-async:
     runs-on: ubuntu-latest
     services:
       redis:
@@ -33,18 +33,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: install-beta
-        run: rustup toolchain install nightly
+        run: rustup toolchain install beta
       - name: use-beta
-        run: rustup default nightly
-      - name: build
-        run: cargo build
+        run: rustup default beta
+      - name: build-async
+        run: cargo build --features kramer-async
       - name: test-async
-        run: cargo test --features kramer-async --quiet
-        env:
-          REDIS_HOST: localhost
-          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
-      - name: bench-async
-        run: cargo bench --features kramer-async --quiet
+        run: cargo test --features kramer-async
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
@@ -64,13 +59,40 @@ jobs:
         run: rustup default nightly
       - name: build
         run: cargo build
-      - name: test
+      - name: test-sync
         run: cargo test --quiet
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
-      - name: bench-async
+      - name: bench-sync
         run: cargo bench --quiet
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+  nightly-async:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+    steps:
+      - uses: actions/checkout@v1
+      - name: install-beta
+        run: rustup toolchain install nightly
+      - name: use-beta
+        run: rustup default nightly
+      - name: build
+        run: cargo build --features kramer-async
+      - name: test-async
+        run: cargo test --features kramer-async --quiet
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+      - name: bench-async
+        run: cargo bench --features kramer-async --quiet
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   beta:
     runs-on: ubuntu-latest
-    services: &services
+    services:
       redis:
         image: redis
         ports:
@@ -19,12 +19,17 @@ jobs:
         run: cargo build
       - name: test
         run: cargo test --features kramer-async
-        env: &redis-env
+        env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
   nightly-async:
     runs-on: ubuntu-latest
-    services: *services
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
     steps:
       - uses: actions/checkout@v1
       - name: install-beta
@@ -35,13 +40,22 @@ jobs:
         run: cargo build
       - name: test-async
         run: cargo test --features kramer-async --quiet
-        env: *redis-env
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
       - name: bench-async
         run: cargo bench --features kramer-async --quiet
-        env: *redis-env
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
   nightly-sync:
     runs-on: ubuntu-latest
-    services: *services
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
     steps:
       - uses: actions/checkout@v1
       - name: install-beta
@@ -52,7 +66,11 @@ jobs:
         run: cargo build
       - name: test
         run: cargo test --quiet
-        env: *redis-env
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
       - name: bench-async
         run: cargo bench --quiet
-        env: *redis-env
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: build
         run: cargo build
       - name: test
-        run: cargo test --features kramer-io
+        run: cargo test --features kramer-async
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: gh.build
 on: [push]
 jobs:
-  build:
+  beta:
     runs-on: ubuntu-latest
     services:
       redis:
@@ -19,6 +19,37 @@ jobs:
         run: cargo build
       - name: test
         run: cargo test --features kramer-async
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+  nightly:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+    steps:
+      - uses: actions/checkout@v1
+      - name: install-beta
+        run: rustup toolchain install nightly
+      - name: use-beta
+        run: rustup default nightly
+      - name: build
+        run: cargo build
+      - name: test
+        run: cargo test --features kramer-async
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+      - name: bench-async
+        run: cargo bench --features kramer-async
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+      - name: bench-sync
+        run: cargo bench
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   beta:
     runs-on: ubuntu-latest
-    services:
+    services: &services
       redis:
         image: redis
         ports:
@@ -19,17 +19,29 @@ jobs:
         run: cargo build
       - name: test
         run: cargo test --features kramer-async
-        env:
+        env: &redis-env
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
-  nightly:
+  nightly-async:
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
-        options: --entrypoint redis-server
+    services: *services
+    steps:
+      - uses: actions/checkout@v1
+      - name: install-beta
+        run: rustup toolchain install nightly
+      - name: use-beta
+        run: rustup default nightly
+      - name: build
+        run: cargo build
+      - name: test-async
+        run: cargo test --features kramer-async --quiet
+        env: *redis-env
+      - name: bench-async
+        run: cargo bench --features kramer-async --quiet
+        env: *redis-env
+  nightly-sync:
+    runs-on: ubuntu-latest
+    services: *services
     steps:
       - uses: actions/checkout@v1
       - name: install-beta
@@ -39,17 +51,8 @@ jobs:
       - name: build
         run: cargo build
       - name: test
-        run: cargo test --features kramer-async
-        env:
-          REDIS_HOST: localhost
-          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+        run: cargo test --quiet
+        env: *redis-env
       - name: bench-async
-        run: cargo bench --features kramer-async
-        env:
-          REDIS_HOST: localhost
-          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
-      - name: bench-sync
-        run: cargo bench
-        env:
-          REDIS_HOST: localhost
-          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+        run: cargo bench --quiet
+        env: *redis-env

--- a/.todo.md
+++ b/.todo.md
@@ -44,7 +44,9 @@
 | `rpushx`  | [`1a15a9e`] | `ListCommand::Push((Side::Right, Insertion::IfExists), key, Arity::One("kramer")))` |
 | `set`     | [`1a15a9e`] | `StringCommand::Set(Arity::One((key, "kramer")), None, Insertion::Always)` |
 
-# Milestone: 0.2.0
+# Milestone: 0.X.0
+
+These commands are not currently in planning and _may_ not be implemented in this library.
 
 - [ ] auth
 - [ ] bitcount
@@ -181,7 +183,7 @@
 - [ ] xclaim
 - [ ] xpending
 
-# Milestone: 0.X.0
+# Wont-Do
 
 The following commands are not part of the roadmap for this library.
 

--- a/.todo.md
+++ b/.todo.md
@@ -44,6 +44,20 @@
 | `rpushx`  | [`1a15a9e`] | `ListCommand::Push((Side::Right, Insertion::IfExists), key, Arity::One("kramer")))` |
 | `set`     | [`1a15a9e`] | `StringCommand::Set(Arity::One((key, "kramer")), None, Insertion::Always)` |
 
+# Milestone: 0.2.0
+
+| Command     | Introduced  | Use      |
+| :---        | :----       | :----    |
+| `spop`      |             |          |
+| `srem`      |             |          |
+| `sunion`    |             |          |
+| `sadd`      |             |          |
+| `scard `    |             |          |
+| `sdiff`     |             |          |
+| `sismember` |             |          |
+| `sinter`    |             |          |
+| `smembers`  |             |          |
+
 # Milestone: 0.X.0
 
 These commands are not currently in planning and _may_ not be implemented in this library.
@@ -106,30 +120,21 @@ These commands are not currently in planning and _may_ not be implemented in thi
 - [ ] restore
 - [ ] role
 - [ ] rpoplpush
-- [ ] sadd
 - [ ] save
-- [ ] scard
-- [ ] sdiff
 - [ ] sdiffstore
 - [ ] select
 - [ ] setbit
 - [ ] setrange
 - [ ] shutdown
-- [ ] sinter
 - [ ] sinterstore
-- [ ] sismember
 - [ ] slaveof
 - [ ] replicaof
 - [ ] slowlog
-- [ ] smembers
 - [ ] smove
 - [ ] sort
-- [ ] spop
 - [ ] srandmember
-- [ ] srem
 - [ ] strlen
 - [ ] subscribe
-- [ ] sunion
 - [ ] sunionstore
 - [ ] swapdb
 - [ ] sync

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ version = "^0.99"
 optional = true
 
 [features]
-kramer-io = ["async-std"]
+kramer-async = ["async-std"]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 An implementation of the [redis protocol specification][redis] with an execution helper using the
 [`TcpStream`][tcp-stream] provided by [async-std].
 
-
 For a list of supported commands see [todo.md](/.todo.md).
+
+| kramer |
+| --- |
+| ![kramer][kramer] |
 
 ## Contributing
 
@@ -21,3 +24,4 @@ See [CONTRIBUTING](/CONTRIBUTING.md).
 [docs.url]: https://docs.rs/kramer/latest
 [crates.url]: https://crates.io/crates/kramer
 [crates.img]: https://img.shields.io/crates/v/kramer
+[kramer]: https://user-images.githubusercontent.com/1545348/68049259-d341d600-fcb8-11e9-9f25-e1bcf122cd59.gif

--- a/benches/async_bench.rs
+++ b/benches/async_bench.rs
@@ -1,0 +1,34 @@
+#![cfg(feature = "kramer-async")]
+#![feature(test)]
+
+extern crate async_std;
+extern crate test;
+
+use async_std::task;
+use kramer::{execute, Arity, Command, Insertion, StringCommand};
+use std::env::var;
+use test::Bencher;
+
+fn get_redis_url() -> String {
+  let host = var("REDIS_HOST").unwrap_or(String::from("0.0.0.0"));
+  let port = var("REDIS_PORT").unwrap_or(String::from("6379"));
+  format!("{}:{}", host, port)
+}
+
+#[bench]
+fn bench_kramer_set_del_async(b: &mut Bencher) {
+  b.iter(|| {
+    task::block_on(async {
+      let key = "kramer_async";
+      let mut stream = async_std::net::TcpStream::connect(get_redis_url())
+        .await
+        .expect("connected");
+      let set_cmd = StringCommand::Set(Arity::One((key, "42")), None, Insertion::Always);
+      execute(&mut stream, set_cmd).await.expect("written");
+      let del_cmd = Command::Del(Arity::One(key));
+      execute(&mut stream, del_cmd).await.expect("written");
+      Ok::<(), std::io::Error>(())
+    })
+    .expect("ran async");
+  });
+}

--- a/benches/sync_bench.rs
+++ b/benches/sync_bench.rs
@@ -1,0 +1,27 @@
+#![cfg(not(feature = "kramer-async"))]
+#![feature(test)]
+
+extern crate test;
+
+use kramer::{execute, Arity, Command, Insertion, StringCommand};
+use std::env::var;
+use test::Bencher;
+
+fn get_redis_url() -> String {
+  let host = var("REDIS_HOST").unwrap_or(String::from("0.0.0.0"));
+  let port = var("REDIS_PORT").unwrap_or(String::from("6379"));
+  format!("{}:{}", host, port)
+}
+
+#[bench]
+fn bench_kramer_set_del_sync(b: &mut Bencher) {
+  b.iter(|| {
+    let key = "kramer_async";
+    let mut stream = std::net::TcpStream::connect(get_redis_url()).expect("connected");
+    let set_cmd = StringCommand::Set(Arity::One((key, "42")), None, Insertion::Always);
+    execute(&mut stream, set_cmd).expect("written");
+    let del_cmd = Command::Del(Arity::One(key));
+    execute(&mut stream, del_cmd).expect("written");
+    Ok::<(), std::io::Error>(())
+  });
+}

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -1,82 +1,13 @@
-#![cfg(feature = "kramer-io")]
+#![cfg(feature = "kramer-async")]
 
 extern crate async_std;
+
+use crate::response::{readline, Response, ResponseLine, ResponseValue};
 
 use async_std::net::TcpStream;
 use async_std::prelude::*;
 
 use std::io::{Error, ErrorKind};
-
-#[derive(Debug)]
-pub enum ResponseLine {
-  Array(usize),
-  SimpleString(String),
-  Error(String),
-  Integer(i64),
-  BulkString(usize),
-  Null,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum ResponseValue {
-  Empty,
-  String(String),
-  Integer(i64),
-}
-
-#[derive(Debug, PartialEq)]
-pub enum Response {
-  Array(Vec<ResponseValue>),
-  Item(ResponseValue),
-  Error,
-}
-
-fn read_line_size(line: String) -> Result<Option<usize>, Error> {
-  match line.split_at(1).1 {
-    "-1" => Ok(None),
-    value => value
-      .parse::<usize>()
-      .map_err(|e| {
-        Error::new(
-          ErrorKind::Other,
-          format!("invalid array length value '{}': {}", line.as_str(), e),
-        )
-      })
-      .map(|v| Some(v)),
-  }
-}
-
-fn readline(result: Option<Result<String, Error>>) -> Result<ResponseLine, Error> {
-  let line = result.ok_or_else(|| Error::new(ErrorKind::Other, "no line to work with"))??;
-
-  match line.bytes().next() {
-    Some(b'*') => match read_line_size(line)? {
-      None => Ok(ResponseLine::Null),
-      Some(size) => Ok(ResponseLine::Array(size)),
-    },
-    Some(b'$') => match read_line_size(line)? {
-      Some(size) => Ok(ResponseLine::BulkString(size)),
-      None => Ok(ResponseLine::Null),
-    },
-    Some(b'-') => Ok(ResponseLine::Error(line)),
-    Some(b'+') => Ok(ResponseLine::SimpleString(String::from(line.split_at(1).1))),
-    Some(b':') => {
-      let (_, rest) = line.split_at(1);
-      rest
-        .parse::<i64>()
-        .map_err(|e| Error::new(ErrorKind::Other, format!("{:?}", e)))
-        .and_then(|v| Ok(ResponseLine::Integer(v)))
-    }
-    Some(unknown) => Err(Error::new(
-      ErrorKind::Other,
-      format!("invalid message byte leader: {}", unknown),
-    )),
-    None => Err(Error::new(
-      ErrorKind::Other,
-      "empty line in response, unable to determine type",
-    )),
-  }
-}
 
 pub async fn read<C>(connection: C) -> Result<Response, Error>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,18 @@
 //! [redis]: https://redis.io/topics/protocol
 //! [async-std]: https://github.com/async-rs/async-std
 //! [tcp-stream]: https://docs.rs/async-std/0.99.11/async_std/net/struct.TcpStream.html
-#[cfg(feature = "kramer-io")]
-mod io;
-#[cfg(feature = "kramer-io")]
-pub use io::{execute, send, Response, ResponseValue};
+mod response;
+pub use response::{Response, ResponseLine, ResponseValue};
+
+#[cfg(feature = "kramer-async")]
+mod async_io;
+#[cfg(feature = "kramer-async")]
+pub use async_io::{execute, read, send};
+
+#[cfg(not(feature = "kramer-async"))]
+mod sync_io;
+#[cfg(not(feature = "kramer-async"))]
+pub use sync_io::{execute, read, send};
 
 mod modifiers;
 use modifiers::format_bulk_string;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,72 @@
+use std::io::{Error, ErrorKind};
+
+#[derive(Debug)]
+pub enum ResponseLine {
+  Array(usize),
+  SimpleString(String),
+  Error(String),
+  Integer(i64),
+  BulkString(usize),
+  Null,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ResponseValue {
+  Empty,
+  String(String),
+  Integer(i64),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Response {
+  Array(Vec<ResponseValue>),
+  Item(ResponseValue),
+  Error,
+}
+
+fn read_line_size(line: String) -> Result<Option<usize>, Error> {
+  match line.split_at(1).1 {
+    "-1" => Ok(None),
+    value => value
+      .parse::<usize>()
+      .map_err(|e| {
+        Error::new(
+          ErrorKind::Other,
+          format!("invalid array length value '{}': {}", line.as_str(), e),
+        )
+      })
+      .map(|v| Some(v)),
+  }
+}
+
+pub fn readline(result: Option<Result<String, Error>>) -> Result<ResponseLine, Error> {
+  let line = result.ok_or_else(|| Error::new(ErrorKind::Other, "no line to work with"))??;
+
+  match line.bytes().next() {
+    Some(b'*') => match read_line_size(line)? {
+      None => Ok(ResponseLine::Null),
+      Some(size) => Ok(ResponseLine::Array(size)),
+    },
+    Some(b'$') => match read_line_size(line)? {
+      Some(size) => Ok(ResponseLine::BulkString(size)),
+      None => Ok(ResponseLine::Null),
+    },
+    Some(b'-') => Ok(ResponseLine::Error(line)),
+    Some(b'+') => Ok(ResponseLine::SimpleString(String::from(line.split_at(1).1))),
+    Some(b':') => {
+      let (_, rest) = line.split_at(1);
+      rest
+        .parse::<i64>()
+        .map_err(|e| Error::new(ErrorKind::Other, format!("{:?}", e)))
+        .and_then(|v| Ok(ResponseLine::Integer(v)))
+    }
+    Some(unknown) => Err(Error::new(
+      ErrorKind::Other,
+      format!("invalid message byte leader: {}", unknown),
+    )),
+    None => Err(Error::new(
+      ErrorKind::Other,
+      "empty line in response, unable to determine type",
+    )),
+  }
+}

--- a/src/sync_io.rs
+++ b/src/sync_io.rs
@@ -1,0 +1,71 @@
+use crate::response::{readline, Response, ResponseLine, ResponseValue};
+use std::io::prelude::*;
+use std::io::{Error, ErrorKind};
+
+pub fn read<C>(read: C) -> Result<Response, Error>
+where
+  C: std::io::Read + std::marker::Unpin,
+{
+  let mut lines = std::io::BufReader::new(read).lines();
+
+  match readline(lines.next()) {
+    Ok(ResponseLine::Array(size)) => {
+      let mut store = Vec::with_capacity(size);
+
+      if size == 0 {
+        return Ok(Response::Array(vec![]));
+      }
+
+      while let Ok(kind) = readline(lines.next()) {
+        match kind {
+          ResponseLine::BulkString(size) => match lines.next() {
+            Some(Ok(bulky)) if bulky.len() == size => {
+              store.push(ResponseValue::String(bulky));
+            }
+            _ => break,
+          },
+          _ => break,
+        }
+
+        if store.len() >= size {
+          return Ok(Response::Array(store));
+        }
+      }
+
+      Ok(Response::Array(store))
+    }
+    Ok(ResponseLine::BulkString(size)) => {
+      if size < 1 {
+        return Ok(Response::Item(ResponseValue::Empty));
+      }
+
+      let out = lines
+        .next()
+        .ok_or_else(|| Error::new(ErrorKind::Other, "no line to work with"))??;
+
+      Ok(Response::Item(ResponseValue::String(out)))
+    }
+    Ok(ResponseLine::Null) => Ok(Response::Item(ResponseValue::Empty)),
+    Ok(ResponseLine::SimpleString(simple)) => Ok(Response::Item(ResponseValue::String(simple))),
+    Ok(ResponseLine::Integer(value)) => Ok(Response::Item(ResponseValue::Integer(value))),
+    Ok(ResponseLine::Error(e)) => Err(Error::new(ErrorKind::Other, e)),
+    Err(e) => Err(e),
+  }
+}
+
+pub fn execute<C, S>(mut connection: C, message: S) -> Result<Response, Error>
+where
+  S: std::fmt::Display,
+  C: std::io::Write + std::io::Read + std::marker::Unpin,
+{
+  write!(connection, "{}", message)?;
+  read(connection)
+}
+
+pub fn send<S>(addr: &str, message: S) -> Result<Response, Error>
+where
+  S: std::fmt::Display,
+{
+  let mut stream = std::net::TcpStream::connect(addr)?;
+  execute(&mut stream, message)
+}

--- a/tests/execute_async_test.rs
+++ b/tests/execute_async_test.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "kramer-io")]
+#![cfg(feature = "kramer-async")]
 
 extern crate kramer;
 


### PR DESCRIPTION
### would-be breaking change

I split `io.rs` into `async_io.rs` and  `sync_io.rs`. The inclusion of either of these is dependent on the presence of the `kramer-async` feature (previously, `kramer-io`).

#### Also Added

- Started playing with bechmarks
- Updated `.todo.md` with `0.2.0` commands