### PR TITLE
strlen impl

### DIFF
--- a/.todo.md
+++ b/.todo.md
@@ -58,6 +58,12 @@
 | `sinter`    | [`9ee6154`] |          |
 | `smembers`  | [`4989ff3`] |          |
 
+# Milestone: 0.2.1
+
+| Command     | Introduced  | Use      |
+| :---        | :----       | :----    |
+| `strlen`    |             |          |
+
 # Milestone: 0.X.0
 
 These commands are not currently in planning and _may_ not be implemented in this library.
@@ -133,7 +139,6 @@ These commands are not currently in planning and _may_ not be implemented in thi
 - [ ] smove
 - [ ] sort
 - [ ] srandmember
-- [ ] strlen
 - [ ] subscribe
 - [ ] sunionstore
 - [ ] swapdb


### PR DESCRIPTION
added an attempt at coverage for `blpop`, ran into issues with:

```rust
#[test]
fn test_blpush_blocking() {
  let (key, url) = ("test_lpush_blocking", get_redis_url());

  let handle = async_std::task::spawn(async {
    let cmd = Command::List(ListCommand::Pop(Side::Left, "test_lpush_blocking", Some((None, 0))));
    let url = get_redis_url();
    let dest = url.as_str();
    send(url.as_str(), cmd).await.expect("read response from redis")
  });

  async_std::task::block_on(async {
    send(
      url.as_str(),
      Command::List(ListCommand::Push(
        (Side::Left, Insertion::Always),
        key,
        Arity::One("kramer"),
      )),
    )
    .await
    .expect("pushed");
  });

  let result = async_std::task::block_on(handle);
  // ...
}
```

<details>
<summary><code>error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely</code></summary>
<pre><code>
error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
   --> tests/execute_async_test.rs:226:16
    |
226 |   let handle = async_std::task::spawn(async {
    |                ^^^^^^^^^^^^^^^^^^^^^^ `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
    |
   ::: /Users/dadleyy/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-0.99.11/src/task/pool.rs:39:29
    |
39  |     F: Future<Output = T> + Send + 'static,
    |                             ---- required by this bound in `async_std::task::pool::spawn`
    |
    = help: within `core::fmt::Void`, the trait `std::marker::Sync` is not implemented for `*mut (dyn std::ops::Fn() + 'static)`
    = note: required because it appears within the type `std::marker::PhantomData<*mut (dyn std::ops::Fn() + 'static)>`
    = note: required because it appears within the type `core::fmt::Void`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&core::fmt::Void`
    = note: required because it appears within the type `std::fmt::ArgumentV1<'_>`
    = note: required because it appears within the type `[std::fmt::ArgumentV1<'_>; 1]`
    = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13, 't14, 't15> {&mut async_std::net::tcp::stream::TcpStream, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &mut async_std::net::tcp::stream::TcpStream, &'s str, &'t0 str, [&'t1 str; 1], &'t2 [&'t3 str], &'t4 [&'t5 str; 1], kramer::Command<&str>, &'t6 kramer::Command<&str>, (&'t7 kramer::Command<&str>,), [std::fmt::ArgumentV1<'t8>; 1], &'t9 [std::fmt::ArgumentV1<'t10>], &'t11 [std::fmt::ArgumentV1<'t12>; 1], std::fmt::Arguments<'t13>, async_std::io::write::write_fmt::WriteFmtFuture<'t14, &mut async_std::net::tcp::stream::TcpStream>, async_std::io::write::write_fmt::WriteFmtFuture<'t15, &mut async_std::net::tcp::stream::TcpStream>, (), &mut async_std::net::tcp::stream::TcpStream, impl std::future::Future, impl std::future::Future, ()}`
    = note: required because it appears within the type `[static generator@DefId(15:48 ~ kramer[2530]::async_io[0]::execute[0]::{{closure}}[0]) 0:&mut async_std::net::tcp::stream::TcpStream, 1:kramer::Command<&str> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13, 't14, 't15> {&mut async_std::net::tcp::stream::TcpStream, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &mut async_std::net::tcp::stream::TcpStream, &'s str, &'t0 str, [&'t1 str; 1], &'t2 [&'t3 str], &'t4 [&'t5 str; 1], kramer::Command<&str>, &'t6 kramer::Command<&str>, (&'t7 kramer::Command<&str>,), [std::fmt::ArgumentV1<'t8>; 1], &'t9 [std::fmt::ArgumentV1<'t10>], &'t11 [std::fmt::ArgumentV1<'t12>; 1], std::fmt::Arguments<'t13>, async_std::io::write::write_fmt::WriteFmtFuture<'t14, &mut async_std::net::tcp::stream::TcpStream>, async_std::io::write::write_fmt::WriteFmtFuture<'t15, &mut async_std::net::tcp::stream::TcpStream>, (), &mut async_std::net::tcp::stream::TcpStream, impl std::future::Future, impl std::future::Future, ()}]`
    = note: required because it appears within the type `std::future::GenFuture<[static generator@DefId(15:48 ~ kramer[2530]::async_io[0]::execute[0]::{{closure}}[0]) 0:&mut async_std::net::tcp::stream::TcpStream, 1:kramer::Command<&str> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13, 't14, 't15> {&mut async_std::net::tcp::stream::TcpStream, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &mut async_std::net::tcp::stream::TcpStream, &'s str, &'t0 str, [&'t1 str; 1], &'t2 [&'t3 str], &'t4 [&'t5 str; 1], kramer::Command<&str>, &'t6 kramer::Command<&str>, (&'t7 kramer::Command<&str>,), [std::fmt::ArgumentV1<'t8>; 1], &'t9 [std::fmt::ArgumentV1<'t10>], &'t11 [std::fmt::ArgumentV1<'t12>; 1], std::fmt::Arguments<'t13>, async_std::io::write::write_fmt::WriteFmtFuture<'t14, &mut async_std::net::tcp::stream::TcpStream>, async_std::io::write::write_fmt::WriteFmtFuture<'t15, &mut async_std::net::tcp::stream::TcpStream>, (), &mut async_std::net::tcp::stream::TcpStream, impl std::future::Future, impl std::future::Future, ()}]>`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4> {&'r str, kramer::Command<&str>, &'s str, impl std::future::Future, impl std::future::Future, (), async_std::net::tcp::stream::TcpStream, async_std::net::tcp::stream::TcpStream, &'t2 mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str>, impl std::future::Future, impl std::future::Future, ()}`
    = note: required because it appears within the type `[static generator@DefId(15:52 ~ kramer[2530]::async_io[0]::send[0]::{{closure}}[0]) 0:&str, 1:kramer::Command<&str> for<'r, 's, 't0, 't1, 't2, 't3, 't4> {&'r str, kramer::Command<&str>, &'s str, impl std::future::Future, impl std::future::Future, (), async_std::net::tcp::stream::TcpStream, async_std::net::tcp::stream::TcpStream, &'t2 mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str>, impl std::future::Future, impl std::future::Future, ()}]`
    = note: required because it appears within the type `std::future::GenFuture<[static generator@DefId(15:52 ~ kramer[2530]::async_io[0]::send[0]::{{closure}}[0]) 0:&str, 1:kramer::Command<&str> for<'r, 's, 't0, 't1, 't2, 't3, 't4> {&'r str, kramer::Command<&str>, &'s str, impl std::future::Future, impl std::future::Future, (), async_std::net::tcp::stream::TcpStream, async_std::net::tcp::stream::TcpStream, &'t2 mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str>, impl std::future::Future, impl std::future::Future, ()}]>`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7> {kramer::Command<&'r str>, std::string::String, &'s str, &'t0 std::string::String, std::string::String, &'t1 str, &'t2 str, kramer::Command<&'t3 str>, impl std::future::Future, impl std::future::Future, ()}`
    = note: required because it appears within the type `[static generator@tests/execute_async_test.rs:226:45: 231:4 for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7> {kramer::Command<&'r str>, std::string::String, &'s str, &'t0 std::string::String, std::string::String, &'t1 str, &'t2 str, kramer::Command<&'t3 str>, impl std::future::Future, impl std::future::Future, ()}]`
    = note: required because it appears within the type `std::future::GenFuture<[static generator@tests/execute_async_test.rs:226:45: 231:4 for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7> {kramer::Command<&'r str>, std::string::String, &'s str, &'t0 std::string::String, std::string::String, &'t1 str, &'t2 str, kramer::Command<&'t3 str>, impl std::future::Future, impl std::future::Future, ()}]>`
    = note: required because it appears within the type `impl std::future::Future`
</pre></code>
</details>

seems related to [rust-lang/rust#64960](https://github.com/rust-lang/rust/issues/64960)