### PR TITLE
distinct types for valuable commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kramer"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Danny Hadley <dadleyy@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/benches/async_bench.rs
+++ b/benches/async_bench.rs
@@ -26,7 +26,7 @@ fn bench_kramer_set_del_async(b: &mut Bencher) {
         .expect("connected");
       let set_cmd = StringCommand::Set(Arity::One((key, "42")), None, Insertion::Always);
       execute(&mut stream, set_cmd).await.expect("written");
-      let del_cmd = Command::Del(Arity::One(key));
+      let del_cmd = Command::Del::<_, &str>(Arity::One(key));
       execute(&mut stream, del_cmd).await.expect("written");
       Ok::<(), std::io::Error>(())
     })
@@ -59,7 +59,7 @@ fn bench_kramer_set_operations_async(b: &mut Bencher) {
         .await
         .expect("written");
 
-      let result = execute(&mut stream, SetCommand::Inter(Arity::Many(vec![one, two])))
+      let result = execute(&mut stream, SetCommand::Inter::<_, &str>(Arity::Many(vec![one, two])))
         .await
         .expect("written");
 
@@ -68,7 +68,7 @@ fn bench_kramer_set_operations_async(b: &mut Bencher) {
         Response::Array(vec![ResponseValue::String(String::from("kramer"))])
       );
 
-      execute(&mut stream, Command::Del(Arity::Many(vec![one, two])))
+      execute(&mut stream, Command::Del::<_, &str>(Arity::Many(vec![one, two])))
         .await
         .expect("written");
       Ok::<(), std::io::Error>(())

--- a/benches/sync_bench.rs
+++ b/benches/sync_bench.rs
@@ -20,7 +20,7 @@ fn bench_kramer_set_del_sync(b: &mut Bencher) {
     let mut stream = std::net::TcpStream::connect(get_redis_url()).expect("connected");
     let set_cmd = StringCommand::Set(Arity::One((key, "42")), None, Insertion::Always);
     execute(&mut stream, set_cmd).expect("written");
-    let del_cmd = Command::Del(Arity::One(key));
+    let del_cmd = Command::Del::<_, &str>(Arity::One(key));
     execute(&mut stream, del_cmd).expect("written");
     Ok::<(), std::io::Error>(())
   });

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -1,12 +1,13 @@
 use crate::modifiers::{format_bulk_string, Arity, Insertion};
 
 #[derive(Debug)]
-pub enum HashCommand<S>
+pub enum HashCommand<S, V>
 where
   S: std::fmt::Display,
+  V: std::fmt::Display,
 {
   Del(S, Arity<S>),
-  Set(S, Arity<(S, S)>, Insertion),
+  Set(S, Arity<(S, V)>, Insertion),
   Get(S, Option<Arity<S>>),
   StrLen(S, S),
   Len(S),
@@ -16,7 +17,11 @@ where
   Exists(S, S),
 }
 
-impl<S: std::fmt::Display> std::fmt::Display for HashCommand<S> {
+impl<S, V> std::fmt::Display for HashCommand<S, V>
+where
+  S: std::fmt::Display,
+  V: std::fmt::Display,
+{
   fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
     match self {
       HashCommand::StrLen(key, field) => {
@@ -48,7 +53,7 @@ impl<S: std::fmt::Display> std::fmt::Display for HashCommand<S> {
         // Awkward; Get("foo", Some(Arity::Many(vec![]))) == Get("foo", None)
         if len == 0 {
           let formatted = format!("{}", key);
-          return write!(formatter, "{}", HashCommand::Get(formatted, None));
+          return write!(formatter, "{}", HashCommand::Get::<_, &str>(formatted, None));
         }
 
         let tail = fields.iter().map(format_bulk_string).collect::<String>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ where
   Del(Arity<S>),
   Exists(Arity<S>),
   List(ListCommand<S, V>),
-  Strings(StringCommand<S>),
+  Strings(StringCommand<S, V>),
   Hashes(HashCommand<S, V>),
   Sets(SetCommand<S, V>),
   Echo(S),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ where
   Keys(S),
   Del(Arity<S>),
   Exists(Arity<S>),
-  List(ListCommand<S>),
+  List(ListCommand<S, V>),
   Strings(StringCommand<S>),
   Hashes(HashCommand<S, V>),
   Sets(SetCommand<S, V>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ where
   Exists(Arity<S>),
   List(ListCommand<S>),
   Strings(StringCommand<S>),
-  Hashes(HashCommand<S>),
+  Hashes(HashCommand<S, V>),
   Sets(SetCommand<S, V>),
   Echo(S),
 }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,22 +1,27 @@
 use crate::modifiers::{format_bulk_string, Arity, Insertion, Side};
 
 #[derive(Debug)]
-pub enum ListCommand<S>
+pub enum ListCommand<S, V>
 where
   S: std::fmt::Display,
+  V: std::fmt::Display,
 {
   Len(S),
-  Push((Side, Insertion), S, Arity<S>),
+  Push((Side, Insertion), S, Arity<V>),
   Pop(Side, S, Option<(Option<Arity<S>>, u64)>),
-  Rem(S, S, u64),
+  Rem(S, V, u64),
   Index(S, i64),
-  Set(S, u64, S),
-  Insert(S, Side, S, S),
+  Set(S, u64, V),
+  Insert(S, Side, V, V),
   Trim(S, i64, i64),
   Range(S, i64, i64),
 }
 
-impl<S: std::fmt::Display> std::fmt::Display for ListCommand<S> {
+impl<S, V> std::fmt::Display for ListCommand<S, V>
+where
+  S: std::fmt::Display,
+  V: std::fmt::Display,
+{
   fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
     match self {
       ListCommand::Trim(key, start, stop) => {

--- a/src/sets.rs
+++ b/src/sets.rs
@@ -1,22 +1,27 @@
 use crate::modifiers::{format_bulk_string, Arity};
 
 #[derive(Debug)]
-pub enum SetCommand<S>
+pub enum SetCommand<S, V>
 where
   S: std::fmt::Display,
+  V: std::fmt::Display,
 {
-  Add(S, Arity<S>),
-  Rem(S, Arity<S>),
+  Add(S, Arity<V>),
+  Rem(S, Arity<V>),
   Card(S),
   Union(Arity<S>),
   Inter(Arity<S>),
-  IsMember(S, S),
+  IsMember(S, V),
   Diff(Arity<S>),
   Members(S),
   Pop(S, u64),
 }
 
-impl<S: std::fmt::Display> std::fmt::Display for SetCommand<S> {
+impl<S, V> std::fmt::Display for SetCommand<S, V>
+where
+  S: std::fmt::Display,
+  V: std::fmt::Display,
+{
   fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
     match self {
       SetCommand::Card(key) => write!(formatter, "*2\r\n$5\r\nSCARD\r\n{}", format_bulk_string(key)),
@@ -107,33 +112,27 @@ mod tests {
 
   #[test]
   fn test_sadd_single() {
-    let cmd = SetCommand::Add("seasons", Arity::One("one"));
-    let mut buffer = Vec::new();
-    write!(buffer, "{}", cmd).expect("was able to write");
+    let cmd = SetCommand::Add::<_, &str>("seasons", Arity::One("one"));
     assert_eq!(
-      String::from_utf8(buffer).unwrap(),
+      format!("{}", cmd),
       String::from("*3\r\n$4\r\nSADD\r\n$7\r\nseasons\r\n$3\r\none\r\n")
     );
   }
 
   #[test]
   fn test_sadd_multi() {
-    let cmd = SetCommand::Add("seasons", Arity::Many(vec!["one", "two"]));
-    let mut buffer = Vec::new();
-    write!(buffer, "{}", cmd).expect("was able to write");
+    let cmd = SetCommand::Add::<_, &str>("seasons", Arity::Many(vec!["one", "two"]));
     assert_eq!(
-      String::from_utf8(buffer).unwrap(),
+      format!("{}", cmd),
       String::from("*4\r\n$4\r\nSADD\r\n$7\r\nseasons\r\n$3\r\none\r\n$3\r\ntwo\r\n")
     );
   }
 
   #[test]
   fn test_smembers_multi() {
-    let cmd = SetCommand::Members("seasons");
-    let mut buffer = Vec::new();
-    write!(buffer, "{}", cmd).expect("was able to write");
+    let cmd = SetCommand::Members::<_, &str>("seasons");
     assert_eq!(
-      String::from_utf8(buffer).unwrap(),
+      format!("{}", cmd),
       String::from("*2\r\n$8\r\nSMEMBERS\r\n$7\r\nseasons\r\n")
     );
   }
@@ -141,10 +140,8 @@ mod tests {
   #[test]
   fn test_srem_single() {
     let cmd = SetCommand::Rem("seasons", Arity::One("one"));
-    let mut buffer = Vec::new();
-    write!(buffer, "{}", cmd).expect("was able to write");
     assert_eq!(
-      String::from_utf8(buffer).unwrap(),
+      format!("{}", cmd),
       String::from("*3\r\n$4\r\nSREM\r\n$7\r\nseasons\r\n$3\r\none\r\n")
     );
   }
@@ -162,7 +159,7 @@ mod tests {
 
   #[test]
   fn test_scard_multi() {
-    let cmd = SetCommand::Card("seasons");
+    let cmd = SetCommand::Card::<_, &str>("seasons");
     let mut buffer = Vec::new();
     write!(buffer, "{}", cmd).expect("was able to write");
     assert_eq!(
@@ -173,7 +170,7 @@ mod tests {
 
   #[test]
   fn test_sdiff_single() {
-    let cmd = SetCommand::Diff(Arity::One("one"));
+    let cmd = SetCommand::Diff::<_, &str>(Arity::One("one"));
     let mut buffer = Vec::new();
     write!(buffer, "{}", cmd).expect("was able to write");
     assert_eq!(
@@ -184,33 +181,24 @@ mod tests {
 
   #[test]
   fn test_sinter_single() {
-    let cmd = SetCommand::Inter(Arity::One("some"));
-    let mut buffer = Vec::new();
-    write!(buffer, "{}", cmd).expect("was able to write");
-    assert_eq!(
-      String::from_utf8(buffer).unwrap(),
-      String::from("*2\r\n$6\r\nSINTER\r\n$4\r\nsome\r\n")
-    );
+    let cmd = SetCommand::Inter::<_, &str>(Arity::One("some"));
+    assert_eq!(format!("{}", cmd), String::from("*2\r\n$6\r\nSINTER\r\n$4\r\nsome\r\n"));
   }
 
   #[test]
   fn test_sinter_multi() {
-    let cmd = SetCommand::Inter(Arity::Many(vec!["one", "two"]));
-    let mut buffer = Vec::new();
-    write!(buffer, "{}", cmd).expect("was able to write");
+    let cmd = SetCommand::Inter::<_, &str>(Arity::Many(vec!["one", "two"]));
     assert_eq!(
-      String::from_utf8(buffer).unwrap(),
+      format!("{}", cmd),
       String::from("*3\r\n$6\r\nSINTER\r\n$3\r\none\r\n$3\r\ntwo\r\n")
     );
   }
 
   #[test]
   fn test_sdiff_multi() {
-    let cmd = SetCommand::Diff(Arity::Many(vec!["one", "two"]));
-    let mut buffer = Vec::new();
-    write!(buffer, "{}", cmd).expect("was able to write");
+    let cmd = SetCommand::Diff::<_, &str>(Arity::Many(vec!["one", "two"]));
     assert_eq!(
-      String::from_utf8(buffer).unwrap(),
+      format!("{}", cmd),
       String::from("*3\r\n$5\r\nSDIFF\r\n$3\r\none\r\n$3\r\ntwo\r\n")
     );
   }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,19 +1,24 @@
 use crate::modifiers::{format_bulk_string, Arity, Insertion};
 
 #[derive(Debug)]
-pub enum StringCommand<S>
+pub enum StringCommand<S, V>
 where
   S: std::fmt::Display,
+  V: std::fmt::Display,
 {
-  Set(Arity<(S, S)>, Option<std::time::Duration>, Insertion),
+  Set(Arity<(S, V)>, Option<std::time::Duration>, Insertion),
   Get(Arity<S>),
   Len(S),
   Decr(S, usize),
   Incr(S, i64),
-  Append(S, S),
+  Append(S, V),
 }
 
-impl<S: std::fmt::Display> std::fmt::Display for StringCommand<S> {
+impl<S, V> std::fmt::Display for StringCommand<S, V>
+where
+  S: std::fmt::Display,
+  V: std::fmt::Display,
+{
   fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
     match self {
       StringCommand::Len(key) => write!(formatter, "*2\r\n$6\r\nSTRLEN\r\n{}", format_bulk_string(key)),
@@ -79,15 +84,12 @@ impl<S: std::fmt::Display> std::fmt::Display for StringCommand<S> {
 #[cfg(test)]
 mod tests {
   use super::StringCommand;
-  use std::io::prelude::*;
 
   #[test]
   fn tes_strlen_present() {
-    let cmd = StringCommand::Len("seinfeld");
-    let mut buffer = Vec::new();
-    write!(buffer, "{}", cmd).expect("was able to write");
+    let cmd = StringCommand::Len::<_, &str>("seinfeld");
     assert_eq!(
-      String::from_utf8(buffer).unwrap(),
+      format!("{}", cmd),
       String::from("*2\r\n$6\r\nSTRLEN\r\n$8\r\nseinfeld\r\n")
     );
   }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -83,10 +83,19 @@ where
 
 #[cfg(test)]
 mod tests {
-  use super::StringCommand;
+  use super::{Arity, Insertion, StringCommand};
 
   #[test]
-  fn tes_strlen_present() {
+  fn test_set_present() {
+    let cmd = StringCommand::Set(Arity::One(("month", 11)), None, Insertion::Always);
+    assert_eq!(
+      format!("{}", cmd),
+      String::from("*3\r\n$3\r\nSET\r\n$5\r\nmonth\r\n$2\r\n11\r\n")
+    );
+  }
+
+  #[test]
+  fn test_strlen_present() {
     let cmd = StringCommand::Len::<_, &str>("seinfeld");
     assert_eq!(
       format!("{}", cmd),

--- a/tests/execute_async_test.rs
+++ b/tests/execute_async_test.rs
@@ -10,8 +10,8 @@ use kramer::{
 use std::env::var;
 
 #[cfg(test)]
-fn set_field<S: std::fmt::Display>(key: S, field: S, value: S) -> Command<S, String> {
-  Command::Hashes::<_, String>(HashCommand::Set(key, Arity::One((field, value)), Insertion::Always))
+fn set_field<S: std::fmt::Display>(key: S, field: S, value: S) -> Command<S, S> {
+  Command::Hashes::<_, _>(HashCommand::Set(key, Arity::One((field, value)), Insertion::Always))
 }
 
 #[cfg(test)]

--- a/tests/execute_async_test.rs
+++ b/tests/execute_async_test.rs
@@ -10,8 +10,8 @@ use kramer::{
 use std::env::var;
 
 #[cfg(test)]
-fn set_field<S: std::fmt::Display>(key: S, field: S, value: S) -> Command<S> {
-  Command::Hashes(HashCommand::Set(key, Arity::One((field, value)), Insertion::Always))
+fn set_field<S: std::fmt::Display>(key: S, field: S, value: S) -> Command<S, String> {
+  Command::Hashes::<_, String>(HashCommand::Set(key, Arity::One((field, value)), Insertion::Always))
 }
 
 #[cfg(test)]
@@ -29,7 +29,7 @@ fn get_redis_url() -> String {
 #[test]
 fn test_echo() {
   let url = get_redis_url();
-  let result = async_std::task::block_on(send(url.as_str(), Command::Echo("hello")));
+  let result = async_std::task::block_on(send(url.as_str(), Command::Echo::<_, &str>("hello")));
   assert_eq!(
     result.unwrap(),
     Response::Item(ResponseValue::String("hello".to_string()))
@@ -39,7 +39,7 @@ fn test_echo() {
 #[test]
 fn test_send_keys() {
   let url = get_redis_url();
-  let result = async_std::task::block_on(send(url.as_str(), Command::Keys("*")));
+  let result = async_std::task::block_on(send(url.as_str(), Command::Keys::<_, &str>("*")));
   assert!(result.is_ok());
 }
 
@@ -50,10 +50,10 @@ fn test_set_vanilla() {
   let result = async_std::task::block_on(async {
     let set_result = send(
       url.as_str(),
-      Command::Strings(StringCommand::Set(Arity::One((key, "kramer")), None, Insertion::Always)),
+      Command::Strings::<_, &str>(StringCommand::Set(Arity::One((key, "kramer")), None, Insertion::Always)),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     set_result
   });
   assert_eq!(
@@ -69,14 +69,14 @@ fn test_set_if_not_exists_w_not_exists() {
   let result = async_std::task::block_on(async {
     let set_result = send(
       url.as_str(),
-      Command::Strings(StringCommand::Set(
+      Command::Strings::<_, &str>(StringCommand::Set(
         Arity::One((key, "kramer")),
         None,
         Insertion::IfNotExists,
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     set_result
   });
   assert_eq!(
@@ -93,19 +93,19 @@ fn test_set_if_not_exists_w_exists() {
   let result = async_std::task::block_on(async {
     send(
       url.as_str(),
-      Command::Strings(StringCommand::Set(Arity::One((key, "kramer")), None, Insertion::Always)),
+      Command::Strings::<_, &str>(StringCommand::Set(Arity::One((key, "kramer")), None, Insertion::Always)),
     )
     .await?;
     let set_result = send(
       url.as_str(),
-      Command::Strings(StringCommand::Set(
+      Command::Strings::<_, &str>(StringCommand::Set(
         arity_single_pair(key, "jerry"),
         None,
         Insertion::IfNotExists,
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     set_result
   });
   assert_eq!(result.unwrap(), Response::Item(ResponseValue::Empty));
@@ -119,14 +119,14 @@ fn test_set_if_exists_w_not_exists() {
   let result = async_std::task::block_on(async {
     let set_result = send(
       url.as_str(),
-      Command::Strings(StringCommand::Set(
+      Command::Strings::<_, &str>(StringCommand::Set(
         arity_single_pair(key, "kramer"),
         None,
         Insertion::IfExists,
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     set_result
   });
   assert_eq!(result.unwrap(), Response::Item(ResponseValue::Empty));
@@ -139,7 +139,7 @@ fn test_set_if_exists_w_exists() {
   let result = async_std::task::block_on(async {
     send(
       url.as_str(),
-      Command::Strings(StringCommand::Set(
+      Command::Strings::<_, &str>(StringCommand::Set(
         arity_single_pair(key, "kramer"),
         None,
         Insertion::Always,
@@ -148,14 +148,14 @@ fn test_set_if_exists_w_exists() {
     .await?;
     let set_result = send(
       url.as_str(),
-      Command::Strings(StringCommand::Set(
+      Command::Strings::<_, &str>(StringCommand::Set(
         arity_single_pair(key, "jerry"),
         None,
         Insertion::IfExists,
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     set_result
   });
   assert_eq!(
@@ -171,14 +171,14 @@ fn test_set_with_duration() {
   let result = async_std::task::block_on(async {
     let set_result = send(
       url.as_str(),
-      Command::Strings(StringCommand::Set(
+      Command::Strings::<_, &str>(StringCommand::Set(
         arity_single_pair(key, "kramer"),
         Some(std::time::Duration::new(10, 0)),
         Insertion::Always,
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     set_result
   });
   assert_eq!(
@@ -194,7 +194,7 @@ fn test_blpush_single() {
   let result = async_std::task::block_on(async {
     send(
       url.as_str(),
-      Command::List(ListCommand::Push(
+      Command::List::<_, &str>(ListCommand::Push(
         (Side::Left, Insertion::Always),
         key,
         Arity::One("kramer"),
@@ -203,10 +203,10 @@ fn test_blpush_single() {
     .await?;
     let out = send(
       url.as_str(),
-      Command::List(ListCommand::Pop(Side::Left, key, Some((None, 0)))),
+      Command::List::<_, &str>(ListCommand::Pop(Side::Left, key, Some((None, 0)))),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -224,7 +224,7 @@ fn test_blpush_blocking() {
   let (key, url) = ("test_lpush_blocking", get_redis_url());
 
   let handle = async_std::task::spawn(async {
-    let cmd = Command::List(ListCommand::Pop(Side::Left, "test_lpush_blocking", Some((None, 0))));
+    let cmd = Command::List::<_, &str>(ListCommand::Pop(Side::Left, "test_lpush_blocking", Some((None, 0))));
     let url = get_redis_url();
     let dest = url.as_str();
     let mut con = async_std::net::TcpStream::connect(dest).await.expect("foo");
@@ -236,7 +236,7 @@ fn test_blpush_blocking() {
   async_std::task::block_on(async {
     send(
       url.as_str(),
-      Command::List(ListCommand::Push(
+      Command::List::<_, &str>(ListCommand::Push(
         (Side::Left, Insertion::Always),
         key,
         Arity::One("kramer"),
@@ -264,14 +264,14 @@ fn test_lpush_single() {
   let result = async_std::task::block_on(async {
     let out = send(
       url.as_str(),
-      Command::List(ListCommand::Push(
+      Command::List::<_, &str>(ListCommand::Push(
         (Side::Left, Insertion::Always),
         key,
         Arity::One("kramer"),
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -283,14 +283,14 @@ fn test_llen_single() {
   let (key, url) = ("test_llen_single", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let ins = Command::List(ListCommand::Push(
+    let ins = Command::List::<_, &str>(ListCommand::Push(
       (Side::Left, Insertion::Always),
       key,
       Arity::One("kramer"),
     ));
     send(url.as_str(), ins).await?;
-    let result = send(url.as_str(), Command::List(ListCommand::Len(key))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let result = send(url.as_str(), Command::List::<_, &str>(ListCommand::Len(key))).await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -304,14 +304,14 @@ fn test_lpush_multi() {
   let result = async_std::task::block_on(async {
     let out = send(
       url.as_str(),
-      Command::List(ListCommand::Push(
+      Command::List::<_, &str>(ListCommand::Push(
         (Side::Left, Insertion::Always),
         key,
         Arity::Many(vec!["kramer", "jerry"]),
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -325,14 +325,14 @@ fn test_lpushx_single_w_no_exists() {
   let result = async_std::task::block_on(async {
     let out = send(
       url.as_str(),
-      Command::List(ListCommand::Push(
+      Command::List::<_, &str>(ListCommand::Push(
         (Side::Left, Insertion::IfExists),
         key,
         Arity::One("kramer"),
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -346,7 +346,7 @@ fn test_lpushx_single_w_exists() {
   let result = async_std::task::block_on(async {
     send(
       url.as_str(),
-      Command::List(ListCommand::Push(
+      Command::List::<_, &str>(ListCommand::Push(
         (Side::Left, Insertion::Always),
         key,
         Arity::One("kramer"),
@@ -355,14 +355,14 @@ fn test_lpushx_single_w_exists() {
     .await?;
     let out = send(
       url.as_str(),
-      Command::List(ListCommand::Push(
+      Command::List::<_, &str>(ListCommand::Push(
         (Side::Left, Insertion::IfExists),
         key,
         Arity::One("kramer"),
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -376,14 +376,14 @@ fn test_rpush_single() {
   let result = async_std::task::block_on(async {
     let set_result = send(
       url.as_str(),
-      Command::List(ListCommand::Push(
+      Command::List::<_, &str>(ListCommand::Push(
         (Side::Right, Insertion::Always),
         key,
         Arity::One("kramer"),
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     set_result
   });
 
@@ -395,14 +395,18 @@ fn test_lpop_single() {
   let (key, url) = ("test_lpop_single", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let push = Command::List(ListCommand::Push(
+    let push = Command::List::<_, &str>(ListCommand::Push(
       (Side::Right, Insertion::Always),
       key,
       Arity::Many(vec!["kramer", "jerry"]),
     ));
     send(url.as_str(), push).await?;
-    let result = send(url.as_str(), Command::List(ListCommand::Pop(Side::Left, key, None))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let result = send(
+      url.as_str(),
+      Command::List::<_, &str>(ListCommand::Pop(Side::Left, key, None)),
+    )
+    .await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -417,14 +421,18 @@ fn test_rpop_single() {
   let (key, url) = ("test_rpop_single", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let push = Command::List(ListCommand::Push(
+    let push = Command::List::<_, &str>(ListCommand::Push(
       (Side::Right, Insertion::Always),
       key,
       Arity::Many(vec!["kramer", "jerry"]),
     ));
     send(url.as_str(), push).await?;
-    let result = send(url.as_str(), Command::List(ListCommand::Pop(Side::Right, key, None))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let result = send(
+      url.as_str(),
+      Command::List::<_, &str>(ListCommand::Pop(Side::Right, key, None)),
+    )
+    .await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -441,14 +449,14 @@ fn test_rpush_multiple() {
   let result = async_std::task::block_on(async {
     let set_result = send(
       url.as_str(),
-      Command::List(ListCommand::Push(
+      Command::List::<_, &str>(ListCommand::Push(
         (Side::Right, Insertion::Always),
         key,
         Arity::Many(vec!["kramer", "jerry"]),
       )),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     set_result
   });
 
@@ -460,8 +468,12 @@ fn test_append() {
   let (key, url) = ("test_append", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let set_result = send(url.as_str(), Command::Strings(StringCommand::Append(key, "jerry"))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let set_result = send(
+      url.as_str(),
+      Command::Strings::<_, &str>(StringCommand::Append(key, "jerry")),
+    )
+    .await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     set_result
   });
 
@@ -473,9 +485,17 @@ fn test_get() {
   let (key, url) = ("test_get", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    send(url.as_str(), Command::Strings(StringCommand::Append(key, "jerry"))).await?;
-    let result = send(url.as_str(), Command::Strings(StringCommand::Get(Arity::One(key)))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(
+      url.as_str(),
+      Command::Strings::<_, &str>(StringCommand::Append(key, "jerry")),
+    )
+    .await?;
+    let result = send(
+      url.as_str(),
+      Command::Strings::<_, &str>(StringCommand::Get(Arity::One(key))),
+    )
+    .await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -490,10 +510,22 @@ fn test_get_multi_append() {
   let (key, url) = ("test_get_multi_append", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    send(url.as_str(), Command::Strings(StringCommand::Append(key, "jerry"))).await?;
-    send(url.as_str(), Command::Strings(StringCommand::Append(key, "kramer"))).await?;
-    let result = send(url.as_str(), Command::Strings(StringCommand::Get(Arity::One(key)))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(
+      url.as_str(),
+      Command::Strings::<_, &str>(StringCommand::Append(key, "jerry")),
+    )
+    .await?;
+    send(
+      url.as_str(),
+      Command::Strings::<_, &str>(StringCommand::Append(key, "kramer")),
+    )
+    .await?;
+    let result = send(
+      url.as_str(),
+      Command::Strings::<_, &str>(StringCommand::Get(Arity::One(key))),
+    )
+    .await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -508,15 +540,23 @@ fn test_multi_get() {
   let (one, two, url) = ("test_multi_get_1", "test_multi_get_2", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    send(url.as_str(), Command::Strings(StringCommand::Append(one, "jerry"))).await?;
-    send(url.as_str(), Command::Strings(StringCommand::Append(two, "kramer"))).await?;
+    send(
+      url.as_str(),
+      Command::Strings::<_, &str>(StringCommand::Append(one, "jerry")),
+    )
+    .await?;
+    send(
+      url.as_str(),
+      Command::Strings::<_, &str>(StringCommand::Append(two, "kramer")),
+    )
+    .await?;
     let result = send(
       url.as_str(),
-      Command::Strings(StringCommand::Get(Arity::Many(vec![one, two]))),
+      Command::Strings::<_, &str>(StringCommand::Get(Arity::Many(vec![one, two]))),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(one))).await?;
-    send(url.as_str(), Command::Del(Arity::One(two))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(one))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(two))).await?;
     result
   });
 
@@ -534,10 +574,10 @@ fn test_decr_single() {
   let (key, url) = ("test_decr_single", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let push = Command::Strings(StringCommand::Set(arity_single_pair(key, "3"), None, Insertion::Always));
+    let push = Command::Strings::<_, &str>(StringCommand::Set(arity_single_pair(key, "3"), None, Insertion::Always));
     send(url.as_str(), push).await?;
-    let result = send(url.as_str(), Command::Strings(StringCommand::Decr(key, 1))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let result = send(url.as_str(), Command::Strings::<_, &str>(StringCommand::Decr(key, 1))).await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -549,10 +589,10 @@ fn test_decrby_single() {
   let (key, url) = ("test_decrby_single", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let push = Command::Strings(StringCommand::Set(arity_single_pair(key, "3"), None, Insertion::Always));
+    let push = Command::Strings::<_, &str>(StringCommand::Set(arity_single_pair(key, "3"), None, Insertion::Always));
     send(url.as_str(), push).await?;
-    let result = send(url.as_str(), Command::Strings(StringCommand::Decr(key, 2))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let result = send(url.as_str(), Command::Strings::<_, &str>(StringCommand::Decr(key, 2))).await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -564,9 +604,9 @@ fn test_hset_single() {
   let (key, url) = ("test_hset_single", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let do_set = Command::Hashes(HashCommand::Set(key, Arity::One(("name", "kramer")), Insertion::Always));
+    let do_set = Command::Hashes::<_, &str>(HashCommand::Set(key, Arity::One(("name", "kramer")), Insertion::Always));
     let result = send(url.as_str(), do_set).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -578,13 +618,13 @@ fn test_hset_multi() {
   let (key, url) = ("test_hset_multi", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let do_set = Command::Hashes(HashCommand::Set(
+    let do_set = Command::Hashes::<_, &str>(HashCommand::Set(
       key,
       Arity::Many(vec![("name", "kramer"), ("friend", "jerry")]),
       Insertion::Always,
     ));
     let result = send(url.as_str(), do_set).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -598,12 +638,12 @@ fn test_hdel_single() {
   let result = async_std::task::block_on(async {
     send(
       url.as_str(),
-      Command::Hashes(HashCommand::Set(key, Arity::One(("name", "kramer")), Insertion::Always)),
+      Command::Hashes::<_, &str>(HashCommand::Set(key, Arity::One(("name", "kramer")), Insertion::Always)),
     )
     .await?;
-    let del = Command::Hashes(HashCommand::Del(key, Arity::One("name")));
+    let del = Command::Hashes::<_, &str>(HashCommand::Del(key, Arity::One("name")));
     let result = send(url.as_str(), del).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -617,16 +657,16 @@ fn test_hdel_multi() {
   let result = async_std::task::block_on(async {
     send(
       url.as_str(),
-      Command::Hashes(HashCommand::Set(
+      Command::Hashes::<_, &str>(HashCommand::Set(
         key,
         Arity::Many(vec![("name", "kramer"), ("friend", "jerry")]),
         Insertion::Always,
       )),
     )
     .await?;
-    let del = Command::Hashes(HashCommand::Del(key, Arity::Many(vec!["name", "friend", "foo"])));
+    let del = Command::Hashes::<_, &str>(HashCommand::Del(key, Arity::Many(vec!["name", "friend", "foo"])));
     let result = send(url.as_str(), del).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -638,13 +678,13 @@ fn test_hsetnx_single_w_no_exists() {
   let (key, url) = ("test_hsetnx_single_w_no_exists", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let do_set = Command::Hashes(HashCommand::Set(
+    let do_set = Command::Hashes::<_, &str>(HashCommand::Set(
       key,
       Arity::One(("name", "kramer")),
       Insertion::IfNotExists,
     ));
     let result = send(url.as_str(), do_set).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -656,15 +696,15 @@ fn test_hsetnx_single_w_exists() {
   let (key, url) = ("test_hsetnx_single_w_exists", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let pre_set = Command::Hashes(HashCommand::Set(key, Arity::One(("name", "kramer")), Insertion::Always));
+    let pre_set = Command::Hashes::<_, &str>(HashCommand::Set(key, Arity::One(("name", "kramer")), Insertion::Always));
     send(url.as_str(), pre_set).await?;
-    let do_set = Command::Hashes(HashCommand::Set(
+    let do_set = Command::Hashes::<_, &str>(HashCommand::Set(
       key,
       Arity::One(("name", "kramer")),
       Insertion::IfNotExists,
     ));
     let result = send(url.as_str(), do_set).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -678,12 +718,12 @@ fn test_hexists_single() {
   let result = async_std::task::block_on(async {
     send(
       url.as_str(),
-      Command::Hashes(HashCommand::Set(key, Arity::One(("name", "kramer")), Insertion::Always)),
+      Command::Hashes::<_, &str>(HashCommand::Set(key, Arity::One(("name", "kramer")), Insertion::Always)),
     )
     .await?;
-    let exists = Command::Hashes(HashCommand::Exists(key, "name"));
+    let exists = Command::Hashes::<_, &str>(HashCommand::Exists(key, "name"));
     let result = send(url.as_str(), exists).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -695,9 +735,9 @@ fn test_hexists_not_found() {
   let (key, url) = ("test_hexists_not_found", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let exists = Command::Hashes(HashCommand::Exists(key, "name"));
+    let exists = Command::Hashes::<_, &str>(HashCommand::Exists(key, "name"));
     let result = send(url.as_str(), exists).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -711,9 +751,9 @@ fn test_hgetall_values() {
   let result = async_std::task::block_on(async {
     send(url.as_str(), set_field(key, "name", "kramer")).await?;
     send(url.as_str(), set_field(key, "friend", "jerry")).await?;
-    let getall = Command::Hashes(HashCommand::Get(key, None));
+    let getall = Command::Hashes::<_, &str>(HashCommand::Get(key, None));
     let result = send(url.as_str(), getall).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -733,9 +773,9 @@ fn test_hgetall_empty() {
   let (key, url) = ("test_hgetall_empty", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let getall = Command::Hashes(HashCommand::Get(key, None));
+    let getall = Command::Hashes::<_, &str>(HashCommand::Get(key, None));
     let result = send(url.as_str(), getall).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -748,9 +788,9 @@ fn test_hget_values() {
 
   let result = async_std::task::block_on(async {
     send(url.as_str(), set_field(key, "name", "kramer")).await?;
-    let getall = Command::Hashes(HashCommand::Get(key, Some(Arity::One("name"))));
+    let getall = Command::Hashes::<_, &str>(HashCommand::Get(key, Some(Arity::One("name"))));
     let result = send(url.as_str(), getall).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -767,9 +807,9 @@ fn test_hmget_values() {
   let result = async_std::task::block_on(async {
     send(url.as_str(), set_field(key, "name", "kramer")).await?;
     send(url.as_str(), set_field(key, "friend", "jerry")).await?;
-    let getall = Command::Hashes(HashCommand::Get(key, Some(Arity::Many(vec!["name", "friend"]))));
+    let getall = Command::Hashes::<_, &str>(HashCommand::Get(key, Some(Arity::Many(vec!["name", "friend"]))));
     let result = send(url.as_str(), getall).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -788,9 +828,9 @@ fn test_hlen_values() {
 
   let result = async_std::task::block_on(async {
     send(url.as_str(), set_field(key, "name", "kramer")).await?;
-    let getall = Command::Hashes(HashCommand::Len(key));
+    let getall = Command::Hashes::<_, &str>(HashCommand::Len(key));
     let result = send(url.as_str(), getall).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -802,7 +842,7 @@ fn test_hlen_no_exists() {
   let (key, url) = ("test_hlen_no_exists", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let hlen = Command::Hashes(HashCommand::Len(key));
+    let hlen = Command::Hashes::<_, &str>(HashCommand::Len(key));
     send(url.as_str(), hlen).await
   });
 
@@ -815,9 +855,9 @@ fn test_hkeys_values() {
 
   let result = async_std::task::block_on(async {
     send(url.as_str(), set_field(key, "name", "kramer")).await?;
-    let getall = Command::Hashes(HashCommand::Keys(key));
+    let getall = Command::Hashes::<_, &str>(HashCommand::Keys(key));
     let result = send(url.as_str(), getall).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -832,7 +872,7 @@ fn test_hkeys_no_exists() {
   let (key, url) = ("test_hkeys_no_exists", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let hlen = Command::Hashes(HashCommand::Keys(key));
+    let hlen = Command::Hashes::<_, &str>(HashCommand::Keys(key));
     send(url.as_str(), hlen).await
   });
 
@@ -844,7 +884,7 @@ fn test_mset_many() {
   let (one, two, url) = ("test_mset_many_1", "test_mset_many_2", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let do_set = Command::Strings(StringCommand::Set(
+    let do_set = Command::Strings::<_, &str>(StringCommand::Set(
       Arity::Many(vec![(one, "hello"), (two, "goodbye")]),
       None,
       Insertion::Always,
@@ -852,11 +892,11 @@ fn test_mset_many() {
     send(url.as_str(), do_set).await?;
     let result = send(
       url.as_str(),
-      Command::Strings(StringCommand::Get(Arity::Many(vec![one, two]))),
+      Command::Strings::<_, &str>(StringCommand::Get(Arity::Many(vec![one, two]))),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(one))).await?;
-    send(url.as_str(), Command::Del(Arity::One(two))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(one))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(two))).await?;
     result
   });
 
@@ -874,7 +914,7 @@ fn test_msetnx_many() {
   let (one, two, url) = ("test_msetnx_many_1", "test_msetnx_many_2", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let do_set = Command::Strings(StringCommand::Set(
+    let do_set = Command::Strings::<_, &str>(StringCommand::Set(
       Arity::Many(vec![(one, "hello"), (two, "goodbye")]),
       None,
       Insertion::IfNotExists,
@@ -882,11 +922,11 @@ fn test_msetnx_many() {
     send(url.as_str(), do_set).await?;
     let result = send(
       url.as_str(),
-      Command::Strings(StringCommand::Get(Arity::Many(vec![one, two]))),
+      Command::Strings::<_, &str>(StringCommand::Get(Arity::Many(vec![one, two]))),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(one))).await?;
-    send(url.as_str(), Command::Del(Arity::One(two))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(one))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(two))).await?;
     result
   });
 
@@ -910,17 +950,17 @@ fn test_msetnx_already_exists() {
   let result = async_std::task::block_on(async {
     send(
       url.as_str(),
-      Command::Strings(StringCommand::Set(Arity::One((one, "foo")), None, Insertion::Always)),
+      Command::Strings::<_, &str>(StringCommand::Set(Arity::One((one, "foo")), None, Insertion::Always)),
     )
     .await?;
-    let do_set = Command::Strings(StringCommand::Set(
+    let do_set = Command::Strings::<_, &str>(StringCommand::Set(
       Arity::Many(vec![(one, "hello"), (two, "goodbye")]),
       None,
       Insertion::IfNotExists,
     ));
     let result = send(url.as_str(), do_set).await;
-    send(url.as_str(), Command::Del(Arity::One(one))).await?;
-    send(url.as_str(), Command::Del(Arity::One(two))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(one))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(two))).await?;
     result
   });
 
@@ -933,9 +973,9 @@ fn test_hvals_values() {
 
   let result = async_std::task::block_on(async {
     send(url.as_str(), set_field(key, "name", "kramer")).await?;
-    let getall = Command::Hashes(HashCommand::Vals(key));
+    let getall = Command::Hashes::<_, &str>(HashCommand::Vals(key));
     let result = send(url.as_str(), getall).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -951,9 +991,9 @@ fn test_hstrlen_values() {
 
   let result = async_std::task::block_on(async {
     send(url.as_str(), set_field(key, "name", "kramer")).await?;
-    let getall = Command::Hashes(HashCommand::StrLen(key, "name"));
+    let getall = Command::Hashes::<_, &str>(HashCommand::StrLen(key, "name"));
     let result = send(url.as_str(), getall).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -966,14 +1006,14 @@ fn test_hincrby() {
 
   let result = async_std::task::block_on(async {
     send(url.as_str(), set_field(key, "episodes", "10")).await?;
-    let inc = Command::Hashes(HashCommand::Incr(key, "episodes", 10));
+    let inc = Command::Hashes::<_, &str>(HashCommand::Incr(key, "episodes", 10));
     send(url.as_str(), inc).await?;
     let result = send(
       url.as_str(),
-      Command::Hashes(HashCommand::Get(key, Some(Arity::One("episodes")))),
+      Command::Hashes::<_, &str>(HashCommand::Get(key, Some(Arity::One("episodes")))),
     )
     .await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     result
   });
 
@@ -988,14 +1028,14 @@ fn test_lrange() {
   let (key, url) = ("test_lrange", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let ins = Command::List(ListCommand::Push(
+    let ins = Command::List::<_, &str>(ListCommand::Push(
       (Side::Left, Insertion::Always),
       key,
       Arity::One("kramer"),
     ));
     send(url.as_str(), ins).await?;
-    let out = send(url.as_str(), Command::List(ListCommand::Range(key, 0, 10))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let out = send(url.as_str(), Command::List::<_, &str>(ListCommand::Range(key, 0, 10))).await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -1010,14 +1050,14 @@ fn test_lindex_present() {
   let (key, url) = ("test_lindex_present", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let ins = Command::List(ListCommand::Push(
+    let ins = Command::List::<_, &str>(ListCommand::Push(
       (Side::Left, Insertion::Always),
       key,
       Arity::One("kramer"),
     ));
     send(url.as_str(), ins).await?;
-    let out = send(url.as_str(), Command::List(ListCommand::Index(key, 0))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let out = send(url.as_str(), Command::List::<_, &str>(ListCommand::Index(key, 0))).await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -1032,8 +1072,8 @@ fn test_lindex_missing() {
   let (key, url) = ("test_lindex_missing", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let out = send(url.as_str(), Command::List(ListCommand::Index(key, 0))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let out = send(url.as_str(), Command::List::<_, &str>(ListCommand::Index(key, 0))).await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -1045,14 +1085,18 @@ fn test_lrem_present() {
   let (key, url) = ("test_lrem_present", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let ins = Command::List(ListCommand::Push(
+    let ins = Command::List::<_, &str>(ListCommand::Push(
       (Side::Left, Insertion::Always),
       key,
       Arity::One("kramer"),
     ));
     send(url.as_str(), ins).await?;
-    let out = send(url.as_str(), Command::List(ListCommand::Rem(key, "kramer", 1))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let out = send(
+      url.as_str(),
+      Command::List::<_, &str>(ListCommand::Rem(key, "kramer", 1)),
+    )
+    .await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -1064,8 +1108,12 @@ fn test_lrem_missing() {
   let (key, url) = ("test_lrem_missing", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let out = send(url.as_str(), Command::List(ListCommand::Rem(key, "kramer", 1))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let out = send(
+      url.as_str(),
+      Command::List::<_, &str>(ListCommand::Rem(key, "kramer", 1)),
+    )
+    .await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -1077,15 +1125,15 @@ fn test_ltrim_present() {
   let (key, url) = ("test_ltrim_present", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let ins = Command::List(ListCommand::Push(
+    let ins = Command::List::<_, &str>(ListCommand::Push(
       (Side::Right, Insertion::Always),
       key,
       Arity::Many(vec!["kramer", "jerry", "elaine", "george"]),
     ));
     send(url.as_str(), ins).await?;
-    send(url.as_str(), Command::List(ListCommand::Trim(key, 0, 2))).await?;
-    let out = send(url.as_str(), Command::List(ListCommand::Range(key, 0, 10))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::List::<_, &str>(ListCommand::Trim(key, 0, 2))).await?;
+    let out = send(url.as_str(), Command::List::<_, &str>(ListCommand::Range(key, 0, 10))).await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -1104,7 +1152,7 @@ fn test_linsert_left_present() {
   let (key, url) = ("test_linsert_left_present", get_redis_url());
 
   let result = async_std::task::block_on(async {
-    let ins = Command::List(ListCommand::Push(
+    let ins = Command::List::<_, &str>(ListCommand::Push(
       (Side::Right, Insertion::Always),
       key,
       Arity::Many(vec!["kramer", "jerry", "elaine", "george"]),
@@ -1112,11 +1160,11 @@ fn test_linsert_left_present() {
     send(url.as_str(), ins).await?;
     send(
       url.as_str(),
-      Command::List(ListCommand::Insert(key, Side::Left, "george", "newman")),
+      Command::List::<_, &str>(ListCommand::Insert(key, Side::Left, "george", "newman")),
     )
     .await?;
-    let out = send(url.as_str(), Command::List(ListCommand::Range(key, 0, 10))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    let out = send(url.as_str(), Command::List::<_, &str>(ListCommand::Range(key, 0, 10))).await;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 
@@ -1150,7 +1198,7 @@ fn test_linsert_right_present() {
     )
     .await?;
     let out = send(url.as_str(), Command::List(ListCommand::Range(key, 0, 10))).await;
-    send(url.as_str(), Command::Del(Arity::One(key))).await?;
+    send(url.as_str(), Command::Del::<_, &str>(Arity::One(key))).await?;
     out
   });
 

--- a/tests/execute_sync_test.rs
+++ b/tests/execute_sync_test.rs
@@ -20,7 +20,7 @@ fn test_strlen_present() {
     StringCommand::Set(Arity::One((key, "seinfeld")), None, Insertion::Always),
   )
   .expect("executed");
-  let result = execute(&mut con, StringCommand::Len(key)).expect("executed");
+  let result = execute(&mut con, StringCommand::Len::<_, &str>(key)).expect("executed");
   execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(result, Response::Item(ResponseValue::Integer(8)));
 }

--- a/tests/execute_sync_test.rs
+++ b/tests/execute_sync_test.rs
@@ -21,7 +21,7 @@ fn test_strlen_present() {
   )
   .expect("executed");
   let result = execute(&mut con, StringCommand::Len(key)).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(result, Response::Item(ResponseValue::Integer(8)));
 }
 
@@ -31,7 +31,7 @@ fn test_sadd_single() {
   let cmd = SetCommand::Add(key, Arity::One("one"));
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   let result = execute(&mut con, cmd).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(result, Response::Item(ResponseValue::Integer(1)));
 }
 
@@ -41,7 +41,7 @@ fn test_sadd_multi() {
   let cmd = SetCommand::Add(key, Arity::Many(vec!["one", "two"]));
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   let result = execute(&mut con, cmd).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(result, Response::Item(ResponseValue::Integer(2)));
 }
 
@@ -50,9 +50,9 @@ fn test_smembers_multi() {
   let key = "test_smembers_multi";
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   execute(&mut con, SetCommand::Add(key, Arity::Many(vec!["one"]))).expect("executed");
-  let cmd = SetCommand::Members(key);
+  let cmd = SetCommand::Members::<_, &str>(key);
   let result = execute(&mut con, cmd).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(
     result,
     Response::Array(vec![ResponseValue::String(String::from("one")),])
@@ -65,7 +65,7 @@ fn test_srem_single() {
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   execute(&mut con, SetCommand::Add(key, Arity::One("one"))).expect("executed");
   let result = execute(&mut con, SetCommand::Rem(key, Arity::One("one"))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(result, Response::Item(ResponseValue::Integer(1)));
 }
 
@@ -76,7 +76,7 @@ fn test_srem_multi() {
   execute(&mut con, SetCommand::Add(key, Arity::One("one"))).expect("executed");
   execute(&mut con, SetCommand::Add(key, Arity::One("two"))).expect("executed");
   let result = execute(&mut con, SetCommand::Rem(key, Arity::Many(vec!["one", "two"]))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(result, Response::Item(ResponseValue::Integer(2)));
 }
 
@@ -86,8 +86,8 @@ fn test_union_single() {
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   execute(&mut con, SetCommand::Add(key, Arity::One("one"))).expect("executed");
   execute(&mut con, SetCommand::Add(key, Arity::One("two"))).expect("executed");
-  let result = execute(&mut con, SetCommand::Union(Arity::One(key)));
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  let result = execute(&mut con, SetCommand::Union::<_, &str>(Arity::One(key)));
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert!(result.is_ok());
 }
 
@@ -97,9 +97,9 @@ fn test_union_multi() {
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   execute(&mut con, SetCommand::Add(one, Arity::One("one"))).expect("executed");
   execute(&mut con, SetCommand::Add(two, Arity::One("two"))).expect("executed");
-  let result = execute(&mut con, SetCommand::Union(Arity::Many(vec![one, two])));
-  execute(&mut con, Command::Del(Arity::One(one))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(two))).expect("executed");
+  let result = execute(&mut con, SetCommand::Union::<_, &str>(Arity::Many(vec![one, two])));
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(one))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(two))).expect("executed");
   assert!(result.is_ok());
 
   // todo: ordering
@@ -118,8 +118,8 @@ fn test_scard() {
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   execute(&mut con, SetCommand::Add(key, Arity::One("one"))).expect("executed");
   execute(&mut con, SetCommand::Add(key, Arity::One("two"))).expect("executed");
-  let result = execute(&mut con, SetCommand::Card(key)).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  let result = execute(&mut con, SetCommand::Card::<_, &str>(key)).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(result, Response::Item(ResponseValue::Integer(2)));
 }
 
@@ -130,9 +130,9 @@ fn test_diff_none() {
   execute(&mut con, SetCommand::Add(one, Arity::One("one"))).expect("executed");
   execute(&mut con, SetCommand::Add(two, Arity::One("two"))).expect("executed");
   execute(&mut con, SetCommand::Add(two, Arity::One("one"))).expect("executed");
-  let result = execute(&mut con, SetCommand::Diff(Arity::Many(vec![one, two]))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(one))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(two))).expect("executed");
+  let result = execute(&mut con, SetCommand::Diff::<_, &str>(Arity::Many(vec![one, two]))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(one))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(two))).expect("executed");
   assert_eq!(result, Response::Array(vec![]));
 }
 
@@ -141,8 +141,8 @@ fn test_diff_some() {
   let one = "test_diff_some_1";
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   execute(&mut con, SetCommand::Add(one, Arity::One("one"))).expect("executed");
-  let result = execute(&mut con, SetCommand::Diff(Arity::Many(vec![one]))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(one))).expect("executed");
+  let result = execute(&mut con, SetCommand::Diff::<_, &str>(Arity::Many(vec![one]))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(one))).expect("executed");
   assert_eq!(
     result,
     Response::Array(vec![ResponseValue::String(String::from("one"))])
@@ -155,7 +155,7 @@ fn test_ismember_some() {
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   execute(&mut con, SetCommand::Add(key, Arity::One("one"))).expect("executed");
   let result = execute(&mut con, SetCommand::IsMember(key, "one")).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(result, Response::Item(ResponseValue::Integer(1)));
 }
 
@@ -164,7 +164,7 @@ fn test_ismember_none() {
   let key = "test_ismember_none";
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   let result = execute(&mut con, SetCommand::IsMember(key, "one")).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(key))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(key))).expect("executed");
   assert_eq!(result, Response::Item(ResponseValue::Integer(0)));
 }
 
@@ -174,9 +174,9 @@ fn test_inter_none() {
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   execute(&mut con, SetCommand::Add(one, Arity::One("one"))).expect("executed");
   execute(&mut con, SetCommand::Add(two, Arity::One("two"))).expect("executed");
-  let result = execute(&mut con, SetCommand::Inter(Arity::Many(vec![one, two]))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(one))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(two))).expect("executed");
+  let result = execute(&mut con, SetCommand::Inter::<_, &str>(Arity::Many(vec![one, two]))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(one))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(two))).expect("executed");
   assert_eq!(result, Response::Array(vec![]));
 }
 
@@ -186,9 +186,9 @@ fn test_inter_some() {
   let mut con = std::net::TcpStream::connect(get_redis_url()).expect("connection");
   execute(&mut con, SetCommand::Add(one, Arity::One("one"))).expect("executed");
   execute(&mut con, SetCommand::Add(two, Arity::One("one"))).expect("executed");
-  let result = execute(&mut con, SetCommand::Inter(Arity::Many(vec![one, two]))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(one))).expect("executed");
-  execute(&mut con, Command::Del(Arity::One(two))).expect("executed");
+  let result = execute(&mut con, SetCommand::Inter::<_, &str>(Arity::Many(vec![one, two]))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(one))).expect("executed");
+  execute(&mut con, Command::Del::<_, &str>(Arity::One(two))).expect("executed");
   assert_eq!(
     result,
     Response::Array(vec![ResponseValue::String(String::from("one"))])


### PR DESCRIPTION
Commands like `SET key value` _should_ be able to support different types for the `key` and `value` parameters. Initially, all commands were enumerated with a single type parameter, meaning the following was not possible:


```rust
error[E0308]: mismatched types
  --> src/strings.rs:86:34
   |
86 |     let cmd = StringCommand::Set(Arity::One(("seinfeld", 10)), None, Insertion::Always);
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected &str, found integer
   |
   = note: expected type `modifiers::Arity<(_, _)>`
              found type `modifiers::Arity<(&str, {integer})>`
```

### Drawbacks

Unfortunately, this means that creating instances of command variants that do not use a second type must be explicitly typed:

```rust
Command::Del::<_, &str>(Arity::One("some_key"))
```

It feels like there should be a better way to do this, but it is also something one would run into when using `std::error::Error`:

```rust
error[E0282]: type annotations needed
  --> src/strings.rs:91:5
   |
91 |     Ok(1);
   |     ^^ cannot infer type for `E`

error: aborting due to previous error
```

so I think this is worth it for now