### PR TITLE
avoid write macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kramer"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Danny Hadley <dadleyy@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -64,9 +64,9 @@ where
 pub async fn execute<C, S>(mut connection: C, message: S) -> Result<Response, Error>
 where
   S: std::fmt::Display,
-  C: async_std::io::Write + async_std::io::Read + std::marker::Unpin,
+  C: async_std::io::Write + std::marker::Unpin + async_std::io::Read,
 {
-  write!(connection, "{}", message).await?;
+  connection.write_all(format!("{}", message).as_bytes()).await?;
   read(connection).await
 }
 


### PR DESCRIPTION
running into problems on a project using this; it appears something about the `write!` macro doesnt play well when used inside an async block and/or the `async_std::task::block_on` method.

I was able to write a test that fails when using the macro and does not when using `write_all` instead.

<details>
<summary>stacktrace</summary>

```
   Compiling kramer v1.0.0 (/Users/dadleyy/src/dadleyy/sizethree/kramer)
error[E0277]: `core::fmt::Opaque` cannot be shared between threads safely
  --> tests/execute_async_test.rs:62:15
   |
62 |     let one = async_std::task::spawn(async move {
   |               ^^^^^^^^^^^^^^^^^^^^^^ `core::fmt::Opaque` cannot be shared between threads safely
   | 
  ::: /Users/dadleyy/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.0.1/src/task/spawn.rs:28:29
   |
28 |     F: Future<Output = T> + Send + 'static,
   |                             ---- required by this bound in `async_std::task::spawn::spawn`
   |
   = help: the trait `std::marker::Sync` is not implemented for `core::fmt::Opaque`
   = note: required because of the requirements on the impl of `std::marker::Send` for `&core::fmt::Opaque`
   = note: required because it appears within the type `std::fmt::ArgumentV1<'_>`
   = note: required because it appears within the type `[std::fmt::ArgumentV1<'_>; 1]`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13> {std::future::ResumeTy, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str, &str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &'s str, [&'t0 str; 1], &'t1 [&'t2 str], &'t3 [&'t4 str; 1], &'t5 kramer::Command<&str, &str>, (&'t6 kramer::Command<&str, &str>,), [std::fmt::ArgumentV1<'t7>; 1], &'t8 [std::fmt::ArgumentV1<'t9>], &'t10 [std::fmt::ArgumentV1<'t11>; 1], std::fmt::Arguments<'t12>, async_std::io::write::write_fmt::WriteFmtFuture<'t13, &mut async_std::net::tcp::stream::TcpStream>, (), impl std::future::Future}`
   = note: required because it appears within the type `[static generator@kramer::execute::{{closure}}#0 0:&mut async_std::net::tcp::stream::TcpStream, 1:kramer::Command<&str, &str> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13> {std::future::ResumeTy, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str, &str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &'s str, [&'t0 str; 1], &'t1 [&'t2 str], &'t3 [&'t4 str; 1], &'t5 kramer::Command<&str, &str>, (&'t6 kramer::Command<&str, &str>,), [std::fmt::ArgumentV1<'t7>; 1], &'t8 [std::fmt::ArgumentV1<'t9>], &'t10 [std::fmt::ArgumentV1<'t11>; 1], std::fmt::Arguments<'t12>, async_std::io::write::write_fmt::WriteFmtFuture<'t13, &mut async_std::net::tcp::stream::TcpStream>, (), impl std::future::Future}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@kramer::execute::{{closure}}#0 0:&mut async_std::net::tcp::stream::TcpStream, 1:kramer::Command<&str, &str> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13> {std::future::ResumeTy, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str, &str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &'s str, [&'t0 str; 1], &'t1 [&'t2 str], &'t3 [&'t4 str; 1], &'t5 kramer::Command<&str, &str>, (&'t6 kramer::Command<&str, &str>,), [std::fmt::ArgumentV1<'t7>; 1], &'t8 [std::fmt::ArgumentV1<'t9>], &'t10 [std::fmt::ArgumentV1<'t11>; 1], std::fmt::Arguments<'t12>, async_std::io::write::write_fmt::WriteFmtFuture<'t13, &mut async_std::net::tcp::stream::TcpStream>, (), impl std::future::Future}]>`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10> {std::future::ResumeTy, &'r async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>, std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>>, impl std::future::Future, (), async_std::sync::mutex::MutexGuard<'t1, async_std::net::tcp::stream::TcpStream>, &'t2 mut async_std::sync::mutex::MutexGuard<'t3, async_std::net::tcp::stream::TcpStream>, async_std::net::tcp::stream::TcpStream, &'t4 mut async_std::net::tcp::stream::TcpStream, &'t5 str, kramer::Command<&'t6 str, &'t7 str>, impl std::future::Future}`
   = note: required because it appears within the type `[static generator@tests/execute_async_test.rs:62:49: 65:6 a:std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10> {std::future::ResumeTy, &'r async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>, std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>>, impl std::future::Future, (), async_std::sync::mutex::MutexGuard<'t1, async_std::net::tcp::stream::TcpStream>, &'t2 mut async_std::sync::mutex::MutexGuard<'t3, async_std::net::tcp::stream::TcpStream>, async_std::net::tcp::stream::TcpStream, &'t4 mut async_std::net::tcp::stream::TcpStream, &'t5 str, kramer::Command<&'t6 str, &'t7 str>, impl std::future::Future}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@tests/execute_async_test.rs:62:49: 65:6 a:std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10> {std::future::ResumeTy, &'r async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>, std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>>, impl std::future::Future, (), async_std::sync::mutex::MutexGuard<'t1, async_std::net::tcp::stream::TcpStream>, &'t2 mut async_std::sync::mutex::MutexGuard<'t3, async_std::net::tcp::stream::TcpStream>, async_std::net::tcp::stream::TcpStream, &'t4 mut async_std::net::tcp::stream::TcpStream, &'t5 str, kramer::Command<&'t6 str, &'t7 str>, impl std::future::Future}]>`
   = note: required because it appears within the type `impl std::future::Future`

error[E0277]: `core::fmt::Opaque` cannot be shared between threads safely
  --> tests/execute_async_test.rs:67:15
   |
67 |     let two = async_std::task::spawn(async move {
   |               ^^^^^^^^^^^^^^^^^^^^^^ `core::fmt::Opaque` cannot be shared between threads safely
   | 
  ::: /Users/dadleyy/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.0.1/src/task/spawn.rs:28:29
   |
28 |     F: Future<Output = T> + Send + 'static,
   |                             ---- required by this bound in `async_std::task::spawn::spawn`
   |
   = help: the trait `std::marker::Sync` is not implemented for `core::fmt::Opaque`
   = note: required because of the requirements on the impl of `std::marker::Send` for `&core::fmt::Opaque`
   = note: required because it appears within the type `std::fmt::ArgumentV1<'_>`
   = note: required because it appears within the type `[std::fmt::ArgumentV1<'_>; 1]`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13> {std::future::ResumeTy, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str, &str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &'s str, [&'t0 str; 1], &'t1 [&'t2 str], &'t3 [&'t4 str; 1], &'t5 kramer::Command<&str, &str>, (&'t6 kramer::Command<&str, &str>,), [std::fmt::ArgumentV1<'t7>; 1], &'t8 [std::fmt::ArgumentV1<'t9>], &'t10 [std::fmt::ArgumentV1<'t11>; 1], std::fmt::Arguments<'t12>, async_std::io::write::write_fmt::WriteFmtFuture<'t13, &mut async_std::net::tcp::stream::TcpStream>, (), impl std::future::Future}`
   = note: required because it appears within the type `[static generator@kramer::execute::{{closure}}#0 0:&mut async_std::net::tcp::stream::TcpStream, 1:kramer::Command<&str, &str> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13> {std::future::ResumeTy, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str, &str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &'s str, [&'t0 str; 1], &'t1 [&'t2 str], &'t3 [&'t4 str; 1], &'t5 kramer::Command<&str, &str>, (&'t6 kramer::Command<&str, &str>,), [std::fmt::ArgumentV1<'t7>; 1], &'t8 [std::fmt::ArgumentV1<'t9>], &'t10 [std::fmt::ArgumentV1<'t11>; 1], std::fmt::Arguments<'t12>, async_std::io::write::write_fmt::WriteFmtFuture<'t13, &mut async_std::net::tcp::stream::TcpStream>, (), impl std::future::Future}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@kramer::execute::{{closure}}#0 0:&mut async_std::net::tcp::stream::TcpStream, 1:kramer::Command<&str, &str> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13> {std::future::ResumeTy, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str, &str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &'s str, [&'t0 str; 1], &'t1 [&'t2 str], &'t3 [&'t4 str; 1], &'t5 kramer::Command<&str, &str>, (&'t6 kramer::Command<&str, &str>,), [std::fmt::ArgumentV1<'t7>; 1], &'t8 [std::fmt::ArgumentV1<'t9>], &'t10 [std::fmt::ArgumentV1<'t11>; 1], std::fmt::Arguments<'t12>, async_std::io::write::write_fmt::WriteFmtFuture<'t13, &mut async_std::net::tcp::stream::TcpStream>, (), impl std::future::Future}]>`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10> {std::future::ResumeTy, &'r async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>, std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>>, impl std::future::Future, (), async_std::sync::mutex::MutexGuard<'t1, async_std::net::tcp::stream::TcpStream>, &'t2 mut async_std::sync::mutex::MutexGuard<'t3, async_std::net::tcp::stream::TcpStream>, async_std::net::tcp::stream::TcpStream, &'t4 mut async_std::net::tcp::stream::TcpStream, &'t5 str, kramer::Command<&'t6 str, &'t7 str>, impl std::future::Future}`
   = note: required because it appears within the type `[static generator@tests/execute_async_test.rs:67:49: 70:6 b:std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10> {std::future::ResumeTy, &'r async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>, std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>>, impl std::future::Future, (), async_std::sync::mutex::MutexGuard<'t1, async_std::net::tcp::stream::TcpStream>, &'t2 mut async_std::sync::mutex::MutexGuard<'t3, async_std::net::tcp::stream::TcpStream>, async_std::net::tcp::stream::TcpStream, &'t4 mut async_std::net::tcp::stream::TcpStream, &'t5 str, kramer::Command<&'t6 str, &'t7 str>, impl std::future::Future}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@tests/execute_async_test.rs:67:49: 70:6 b:std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10> {std::future::ResumeTy, &'r async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>, std::sync::Arc<async_std::sync::mutex::Mutex<async_std::net::tcp::stream::TcpStream>>, impl std::future::Future, (), async_std::sync::mutex::MutexGuard<'t1, async_std::net::tcp::stream::TcpStream>, &'t2 mut async_std::sync::mutex::MutexGuard<'t3, async_std::net::tcp::stream::TcpStream>, async_std::net::tcp::stream::TcpStream, &'t4 mut async_std::net::tcp::stream::TcpStream, &'t5 str, kramer::Command<&'t6 str, &'t7 str>, impl std::future::Future}]>`
   = note: required because it appears within the type `impl std::future::Future`

error[E0277]: `core::fmt::Opaque` cannot be shared between threads safely
  --> tests/execute_async_test.rs:87:5
   |
87 |     async_std::task::spawn(async {
   |     ^^^^^^^^^^^^^^^^^^^^^^ `core::fmt::Opaque` cannot be shared between threads safely
   | 
  ::: /Users/dadleyy/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.0.1/src/task/spawn.rs:28:29
   |
28 |     F: Future<Output = T> + Send + 'static,
   |                             ---- required by this bound in `async_std::task::spawn::spawn`
   |
   = help: the trait `std::marker::Sync` is not implemented for `core::fmt::Opaque`
   = note: required because of the requirements on the impl of `std::marker::Send` for `&core::fmt::Opaque`
   = note: required because it appears within the type `std::fmt::ArgumentV1<'_>`
   = note: required because it appears within the type `[std::fmt::ArgumentV1<'_>; 1]`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13> {std::future::ResumeTy, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str, &str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &'s str, [&'t0 str; 1], &'t1 [&'t2 str], &'t3 [&'t4 str; 1], &'t5 kramer::Command<&str, &str>, (&'t6 kramer::Command<&str, &str>,), [std::fmt::ArgumentV1<'t7>; 1], &'t8 [std::fmt::ArgumentV1<'t9>], &'t10 [std::fmt::ArgumentV1<'t11>; 1], std::fmt::Arguments<'t12>, async_std::io::write::write_fmt::WriteFmtFuture<'t13, &mut async_std::net::tcp::stream::TcpStream>, (), impl std::future::Future}`
   = note: required because it appears within the type `[static generator@kramer::execute::{{closure}}#0 0:&mut async_std::net::tcp::stream::TcpStream, 1:kramer::Command<&str, &str> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13> {std::future::ResumeTy, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str, &str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &'s str, [&'t0 str; 1], &'t1 [&'t2 str], &'t3 [&'t4 str; 1], &'t5 kramer::Command<&str, &str>, (&'t6 kramer::Command<&str, &str>,), [std::fmt::ArgumentV1<'t7>; 1], &'t8 [std::fmt::ArgumentV1<'t9>], &'t10 [std::fmt::ArgumentV1<'t11>; 1], std::fmt::Arguments<'t12>, async_std::io::write::write_fmt::WriteFmtFuture<'t13, &mut async_std::net::tcp::stream::TcpStream>, (), impl std::future::Future}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@kramer::execute::{{closure}}#0 0:&mut async_std::net::tcp::stream::TcpStream, 1:kramer::Command<&str, &str> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7, 't8, 't9, 't10, 't11, 't12, 't13> {std::future::ResumeTy, &mut async_std::net::tcp::stream::TcpStream, kramer::Command<&str, &str>, &'r mut &mut async_std::net::tcp::stream::TcpStream, &'s str, [&'t0 str; 1], &'t1 [&'t2 str], &'t3 [&'t4 str; 1], &'t5 kramer::Command<&str, &str>, (&'t6 kramer::Command<&str, &str>,), [std::fmt::ArgumentV1<'t7>; 1], &'t8 [std::fmt::ArgumentV1<'t9>], &'t10 [std::fmt::ArgumentV1<'t11>; 1], std::fmt::Arguments<'t12>, async_std::io::write::write_fmt::WriteFmtFuture<'t13, &mut async_std::net::tcp::stream::TcpStream>, (), impl std::future::Future}]>`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1> {std::future::ResumeTy, &'r str, kramer::Command<&str, &str>, impl std::future::Future, (), async_std::net::tcp::stream::TcpStream, &'t0 mut async_std::net::tcp::stream::TcpStream, impl std::future::Future}`
   = note: required because it appears within the type `[static generator@kramer::send::{{closure}}#0 0:&str, 1:kramer::Command<&str, &str> for<'r, 's, 't0, 't1> {std::future::ResumeTy, &'r str, kramer::Command<&str, &str>, impl std::future::Future, (), async_std::net::tcp::stream::TcpStream, &'t0 mut async_std::net::tcp::stream::TcpStream, impl std::future::Future}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@kramer::send::{{closure}}#0 0:&str, 1:kramer::Command<&str, &str> for<'r, 's, 't0, 't1> {std::future::ResumeTy, &'r str, kramer::Command<&str, &str>, impl std::future::Future, (), async_std::net::tcp::stream::TcpStream, &'t0 mut async_std::net::tcp::stream::TcpStream, impl std::future::Future}]>`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `impl std::future::Future`
   = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4> {std::future::ResumeTy, std::string::String, &'r std::string::String, &'s str, kramer::Command<&'t0 str, &'t1 str>, impl std::future::Future, ()}`
   = note: required because it appears within the type `[static generator@tests/execute_async_test.rs:87:34: 90:6 for<'r, 's, 't0, 't1, 't2, 't3, 't4> {std::future::ResumeTy, std::string::String, &'r std::string::String, &'s str, kramer::Command<&'t0 str, &'t1 str>, impl std::future::Future, ()}]`
   = note: required because it appears within the type `std::future::from_generator::GenFuture<[static generator@tests/execute_async_test.rs:87:34: 90:6 for<'r, 's, 't0, 't1, 't2, 't3, 't4> {std::future::ResumeTy, std::string::String, &'r std::string::String, &'s str, kramer::Command<&'t0 str, &'t1 str>, impl std::future::Future, ()}]>`
   = note: required because it appears within the type `impl std::future::Future`

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0277`.
error: could not compile `kramer`.

To learn more, run the command again with --verbose.
```

</details>

it looks like there is [good reason](https://github.com/rust-lang/rust/issues/45197) why the `fmt::Arguments` type is not `Sync`, so I'm guessing the best course of action here is to lean into [`write_all`].

[`write_all`]: https://docs.rs/async-std/1.5.0/async_std/io/trait.Write.html#method.write_all
[`async_std::task::block_on`]: https://docs.rs/async-std/1.5.0/async_std/task/fn.block_on.html