### PR TITLE
partial acl implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: build-async
         run: cargo build --features kramer-async
       - name: test-async
-        run: cargo test --features kramer-async
+        run: cargo test --features kramer-async,acl
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kramer"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Danny Hadley <dadleyy@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -15,3 +15,4 @@ optional = true
 
 [features]
 kramer-async = ["async-std"]
+acl = []

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -1,0 +1,91 @@
+//! Notice: This feature is still not fully implemented and gated behind the `acl` feature flag for
+//! now. The current implementation is designed to _only_ satisfy the single use case so far of
+//! creating an acl entry for a user with a password, command and keys list, e.g:
+//!
+//! ```redis
+//! ACL SETUSER on my-user >my-password ~keys +commands
+//! ```
+//!
+//! This means that the `SetUser` command (with it's respective struct) is only partially
+//! implemented until it is clear what exactly the other variations of it would mean.
+//!
+//! [`SETUSER` docs](https://redis.io/commands/acl-setuser/)
+
+use super::modifiers::format_bulk_string;
+
+/// Notice: Currently `Display` is only implemented if all fields are present/`Some`.
+#[cfg(feature = "acl")]
+#[derive(Debug)]
+pub struct SetUser<S>
+where
+  S:,
+{
+  pub name: S,
+  pub password: Option<S>,
+  pub commands: Option<S>,
+  pub keys: Option<S>,
+}
+
+#[cfg(feature = "acl")]
+#[derive(Debug)]
+pub enum AclCommand<S>
+where
+  S: std::fmt::Display,
+{
+  SetUser(SetUser<S>),
+}
+
+#[cfg(feature = "acl")]
+impl<S> std::fmt::Display for AclCommand<S>
+where
+  S: std::fmt::Display,
+{
+  fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    match self {
+      AclCommand::SetUser(inner) => match (&inner.password, &inner.commands, &inner.keys) {
+        (Some(p), Some(c), Some(k)) => {
+          write!(
+            formatter,
+            "*6\r\n$3\r\nACL\r\n{}{}{}{}{}{}",
+            format_bulk_string("SETUSER"),
+            format_bulk_string(&inner.name),
+            format_bulk_string("on"),
+            format_bulk_string(format!(">{}", p)),
+            format_bulk_string(format!("+{}", c)),
+            format_bulk_string(format!("~{}", k)),
+          )
+        }
+        (_, _, _) => Ok(()),
+      },
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{AclCommand, SetUser};
+
+  #[test]
+  fn format_full_setuser() {
+    let command = AclCommand::SetUser(SetUser {
+      name: "library-member",
+      password: Some("many-books"),
+      commands: Some("hgetall"),
+      keys: Some("books"),
+    });
+
+    assert_eq!(format!("{}", command), "*6\r\n$3\r\nACL\r\n$7\r\nSETUSER\r\n$14\r\nlibrary-member\r\n$2\r\non\r\n$11\r\n>many-books\r\n$8\r\n+hgetall\r\n$6\r\n~books\r\n");
+  }
+
+  #[test]
+  fn format_partial_setuser() {
+    let command = AclCommand::SetUser(SetUser {
+      name: "library-member",
+      password: None,
+      commands: None,
+      keys: None,
+    });
+
+    assert_eq!(format!("{}", command), "")
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,15 @@ pub use sync_io::{execute, read, send};
 
 mod modifiers;
 use modifiers::format_bulk_string;
-pub use modifiers::{Arity, Insertion, Side};
+pub use modifiers::{humanize_command, Arity, Insertion, Side};
 
 mod lists;
 pub use lists::ListCommand;
+
+#[cfg(feature = "acl")]
+pub mod acl;
+#[cfg(feature = "acl")]
+pub use acl::{AclCommand, SetUser};
 
 mod sets;
 pub use sets::SetCommand;
@@ -97,6 +102,9 @@ where
   Sets(SetCommand<S, V>),
   Echo(S),
   Auth(AuthCredentials<S>),
+
+  #[cfg(feature = "acl")]
+  Acl(AclCommand<S>),
 }
 
 impl<S, V> std::fmt::Display for Command<S, V>
@@ -106,6 +114,9 @@ where
 {
   fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
     match self {
+      #[cfg(feature = "acl")]
+      Command::Acl(acl_command) => write!(formatter, "{}", acl_command),
+
       Command::Auth(method) => write!(formatter, "{}", method),
       Command::Echo(value) => write!(formatter, "*2\r\n$4\r\nECHO\r\n{}", format_bulk_string(value)),
       Command::Keys(value) => write!(formatter, "*2\r\n$4\r\nKEYS\r\n{}", format_bulk_string(value)),

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -21,3 +21,38 @@ pub fn format_bulk_string<S: std::fmt::Display>(input: S) -> String {
   let as_str = format!("{}", input);
   format!("${}\r\n{}\r\n", as_str.len(), as_str)
 }
+
+/// By default, all commands will be formatted via the `Display` trait into the string
+/// representation that they would be sent over the wire as. This function should help users
+/// visualize commands in the format that they would issue them into the `redis-cli` as.
+pub fn humanize_command<S, V>(input: &super::Command<S, V>) -> String
+where
+  S: std::fmt::Display,
+  V: std::fmt::Display,
+{
+  let as_str = format!("{}", input);
+  as_str
+    .split("\r\n")
+    .filter_map(|v| {
+      if v.starts_with("$") || v.starts_with("*") {
+        None
+      } else {
+        Some(format!("{} ", v))
+      }
+    })
+    .collect::<String>()
+    .trim_end()
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::humanize_command;
+
+  #[test]
+  fn test_humanize() {
+    let command = crate::Command::Auth::<&str, &str>(crate::AuthCredentials::User(("testing", "testerton")));
+    let humanized = humanize_command(&command);
+    assert_eq!(humanized, "AUTH testing testerton");
+  }
+}


### PR DESCRIPTION
Adding a partial implementation of the `ACL` command that will support my current use case. The variant is hidden behind a feature flag and users should expect it to change over time as more uses are implemented.