### PR TITLE
better errors, clippy, ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,6 @@ jobs:
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
       - name: clippy
         run: cargo clippy
-      - name: release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          generate_release_notes: true
   stable-async:
     runs-on: ubuntu-latest
     services:
@@ -104,4 +99,13 @@ jobs:
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
-
+  release:
+    runs-on: ubuntu-latest
+    needs: ["stable-sync", "stable-async"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
         run: rustup toolchain install stable
       - name: use-stable
         run: rustup default stable
+      - name: add-clippy
+        run: rustup component add clippy
       - name: build-sync
         run: cargo build
       - name: test-sync
@@ -22,6 +24,13 @@ jobs:
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+      - name: clippy
+        run: cargo clippy
+      - name: release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
   stable-async:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,10 @@ jobs:
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
-      - name: clippy
-        run: cargo clippy
+      - name: "clippy: acl"
+        run: cargo clippy --features acl
+      - name: "clippy: async"
+        run: cargo clippy --features kramer-async
   stable-async:
     runs-on: ubuntu-latest
     services:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kramer"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Danny Hadley <dadleyy@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -20,19 +20,30 @@ pub struct SetUser<S>
 where
   S:,
 {
+  /// The name of the ACL entry.
   pub name: S,
+
+  /// An optional password that will be added to the acl command.
   pub password: Option<S>,
+
+  /// The set of commands the ACL entry should have the ability to execute.
   pub commands: Option<S>,
+
+  /// The set of keys the ACL entry should have access to.
   pub keys: Option<S>,
 }
 
+/// Redis acl commands.
 #[cfg(feature = "acl")]
 #[derive(Debug)]
 pub enum AclCommand<S>
 where
   S: std::fmt::Display,
 {
+  /// Wraps the `SetUser` struct for a type implementing display.
   SetUser(SetUser<S>),
+
+  /// Wraps the `DelUser` struct for a type implementing display.
   DelUser(Arity<S>),
 }
 

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -1,19 +1,38 @@
 use crate::modifiers::{format_bulk_string, Arity, Insertion};
 
+/// `HashCommand` represents the possible redis operations of keys that
+/// are a hash type.
 #[derive(Debug)]
 pub enum HashCommand<S, V>
 where
   S: std::fmt::Display,
   V: std::fmt::Display,
 {
+  /// Deletes fields from a given hash.
   Del(S, Arity<S>),
+
+  /// Sets the value of a hash for a given key.
   Set(S, Arity<(S, V)>, Insertion),
+
+  /// Returns the value (or many) stored in a hash at a specific field.
   Get(S, Option<Arity<S>>),
+
+  /// Returns the length of a string stored at a key within a hash.
   StrLen(S, S),
+
+  /// Returns the amount of keys in the given hash.
   Len(S),
+
+  /// Increments a key for the hash by a given amount.
   Incr(S, S, i64),
+
+  /// Returns all keys for the hash stored at a given key.
   Keys(S),
+
+  /// Returns all values for the hash stored at a given key.
   Vals(S),
+
+  /// Checks to see if the given field exists in the hash.
   Exists(S, S),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ where
   /// Auth commands
   Auth(AuthCredentials<S>),
 
+  /// ACL commands; currently unstable.
   #[cfg(feature = "acl")]
   Acl(AclCommand<S>),
 }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -1,19 +1,37 @@
 use crate::modifiers::{format_bulk_string, Arity, Insertion, Side};
 
+/// Lists.
 #[derive(Debug)]
 pub enum ListCommand<S, V>
 where
   S: std::fmt::Display,
   V: std::fmt::Display,
 {
+  /// List length.
   Len(S),
+
+  /// Adds an item to the list on the correct side.
   Push((Side, Insertion), S, Arity<V>),
+
+  ///  Pops an item from the side of a list with the option for a timeout.
   Pop(Side, S, Option<(Option<Arity<S>>, u64)>),
+
+  /// Removes items from a list.
   Rem(S, V, u64),
+
+  /// Returns the index of an item in a list.
   Index(S, i64),
+
+  /// Sets the value of an index of a list.
   Set(S, u64, V),
+
+  /// Inserts a value into a list.
   Insert(S, Side, V, V),
+
+  /// Truncate a list.
   Trim(S, i64, i64),
+
+  /// Return the length of a list.
   Range(S, i64, i64),
 }
 
@@ -78,8 +96,8 @@ where
       ListCommand::Len(key) => write!(formatter, "*2\r\n$4\r\nLLEN\r\n{}", format_bulk_string(key)),
       ListCommand::Pop(side, key, block) => {
         let (cmd, ext, kc) = match (side, block) {
-          (Side::Left, None) => ("LPOP", format!(""), 0),
-          (Side::Right, None) => ("RPOP", format!(""), 0),
+          (Side::Left, None) => ("LPOP", "".to_string(), 0),
+          (Side::Right, None) => ("RPOP", "".to_string(), 0),
           (Side::Left, Some((None, timeout))) => ("BLPOP", format_bulk_string(timeout), 1),
           (Side::Right, Some((None, timeout))) => ("BRPOP", format_bulk_string(timeout), 1),
           (Side::Left, Some((Some(values), timeout))) => {

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -1,22 +1,40 @@
-#[derive(Debug, Clone, PartialEq)]
+/// For lists, items can either be inserted on the left or right; this translates to
+/// whether or not the generated command is `LPOP` or `RPOP` (for example).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Side {
+  /// Insert at the start.
   Left,
+
+  /// Insert at the end.
   Right,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+/// Redis provides the ability to conditionally apply an inseration based on the existence
+/// of the a value that is equal.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Insertion {
+  /// The presence of the value does not matter.
   Always,
+
+  /// The presence of the value is required to insert.
   IfExists,
+
+  /// The presence of the value is forbidden to insert.
   IfNotExists,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+/// The arity type here is used to mean a single or non-single container.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Arity<S> {
+  /// Wraps a `Vec`; many values.
   Many(Vec<S>),
+
+  /// Indicates a single value.
   One(S),
 }
 
+/// This method will return a string that is formatted following the redis serialization protocol
+/// standard to represent a bulk string.
 pub fn format_bulk_string<S: std::fmt::Display>(input: S) -> String {
   let as_str = format!("{}", input);
   format!("${}\r\n{}\r\n", as_str.len(), as_str)
@@ -34,7 +52,7 @@ where
   as_str
     .split("\r\n")
     .filter_map(|v| {
-      if v.starts_with("$") || v.starts_with("*") {
+      if v.starts_with('$') || v.starts_with('*') {
         None
       } else {
         Some(format!("{} ", v))

--- a/src/response.rs
+++ b/src/response.rs
@@ -53,7 +53,7 @@ pub enum Response {
 /// this as a usize and return that value. We're also translating from an integer `-1` value into a
 /// `None` to represent an empty value.
 fn read_line_size(line: String) -> Result<Option<usize>, Error> {
-  match line.split_at(1).1 {
+  match line.trim_end().split_at(1).1 {
     "-1" => Ok(None),
     value => value
       .parse::<usize>()
@@ -81,7 +81,7 @@ pub fn readline(result: String) -> Result<ResponseLine, Error> {
     Some(b'-') => Ok(ResponseLine::Error(result)),
     Some(b'+') => Ok(ResponseLine::SimpleString(String::from(result.split_at(1).1))),
     Some(b':') => {
-      let (_, rest) = result.split_at(1);
+      let (_, rest) = result.trim_end().split_at(1);
       rest
         .parse::<i64>()
         .map_err(|e| Error::new(ErrorKind::Other, format!("{:?}", e)))

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,29 +1,57 @@
 use std::io::{Error, ErrorKind};
 
+/// A response line is the type that is parsed from a single `\r\n` delimited string returned from
+/// the redis server.
 #[derive(Debug)]
 pub enum ResponseLine {
+  /// An array response line indicates we have a string following.
   Array(usize),
+
+  /// A simple string line is typically predicated by a bulk string line.
   SimpleString(String),
+
+  /// The error line includes a message.
   Error(String),
+
+  /// Integers - signed.
   Integer(i64),
+
+  /// The bulk string response is usually part of an array.
   BulkString(usize),
+
+  /// A null response line.
   Null,
 }
 
-#[derive(Debug, PartialEq)]
+/// A redis response value may either be empty, a bulk string, or an integer.
+#[derive(Debug, PartialEq, Eq)]
 pub enum ResponseValue {
+  /// The empty response.
   Empty,
+
+  /// Bulk string responses.
   String(String),
+
+  /// Integer responses.
   Integer(i64),
 }
 
-#[derive(Debug, PartialEq)]
+/// Redis responses may either be an array of values, a single value, or an error.
+#[derive(Debug, PartialEq, Eq)]
 pub enum Response {
+  /// A multi value response.
   Array(Vec<ResponseValue>),
+
+  /// A single value.
   Item(ResponseValue),
+
+  /// The error message returned from redis.
   Error,
 }
 
+/// Most redis responses will be a bulk string, or an integer. In either case, we want to parse
+/// this as a usize and return that value. We're also translating from an integer `-1` value into a
+/// `None` to represent an empty value.
 fn read_line_size(line: String) -> Result<Option<usize>, Error> {
   match line.split_at(1).1 {
     "-1" => Ok(None),
@@ -35,30 +63,29 @@ fn read_line_size(line: String) -> Result<Option<usize>, Error> {
           format!("invalid array length value '{}': {}", line.as_str(), e),
         )
       })
-      .map(|v| Some(v)),
+      .map(Some),
   }
 }
 
-pub fn readline(result: Option<Result<String, Error>>) -> Result<ResponseLine, Error> {
-  let line = result.ok_or_else(|| Error::new(ErrorKind::Other, "no line to work with"))??;
-
-  match line.bytes().next() {
-    Some(b'*') => match read_line_size(line)? {
+/// Given a string, this method will attempt to parse it into our `ResponseLine` enum.
+pub fn readline(result: String) -> Result<ResponseLine, Error> {
+  match result.bytes().next() {
+    Some(b'*') => match read_line_size(result)? {
       None => Ok(ResponseLine::Null),
       Some(size) => Ok(ResponseLine::Array(size)),
     },
-    Some(b'$') => match read_line_size(line)? {
+    Some(b'$') => match read_line_size(result)? {
       Some(size) => Ok(ResponseLine::BulkString(size)),
       None => Ok(ResponseLine::Null),
     },
-    Some(b'-') => Ok(ResponseLine::Error(line)),
-    Some(b'+') => Ok(ResponseLine::SimpleString(String::from(line.split_at(1).1))),
+    Some(b'-') => Ok(ResponseLine::Error(result)),
+    Some(b'+') => Ok(ResponseLine::SimpleString(String::from(result.split_at(1).1))),
     Some(b':') => {
-      let (_, rest) = line.split_at(1);
+      let (_, rest) = result.split_at(1);
       rest
         .parse::<i64>()
         .map_err(|e| Error::new(ErrorKind::Other, format!("{:?}", e)))
-        .and_then(|v| Ok(ResponseLine::Integer(v)))
+        .map(ResponseLine::Integer)
     }
     Some(unknown) => Err(Error::new(
       ErrorKind::Other,

--- a/src/sets.rs
+++ b/src/sets.rs
@@ -1,19 +1,38 @@
 use crate::modifiers::{format_bulk_string, Arity};
 
+/// The `SetCommand` is used for working with redis keys that are sets: unique collections
+/// of values.
 #[derive(Debug)]
 pub enum SetCommand<S, V>
 where
   S: std::fmt::Display,
   V: std::fmt::Display,
 {
+  /// Adds a member(s) to a set.
   Add(S, Arity<V>),
+
+  /// Removes a member(s) to a set.
   Rem(S, Arity<V>),
+
+  /// Returns the amount of members in the set.
   Card(S),
+
+  /// Returns the members of the set resulting from the union of all the given sets.
   Union(Arity<S>),
+
+  /// Returns the members of the set resulting from the intersection of all the given sets.
   Inter(Arity<S>),
+
+  /// Returns whether or not the given value is a member of the set.
   IsMember(S, V),
+
+  /// Returns the members of the set resulting from the difference of all the given sets.
   Diff(Arity<S>),
+
+  /// Returns the members of the set.
   Members(S),
+
+  /// Removes elements from the set.
   Pop(S, u64),
 }
 

--- a/src/sync_io.rs
+++ b/src/sync_io.rs
@@ -2,13 +2,19 @@ use crate::response::{readline, Response, ResponseLine, ResponseValue};
 use std::io::prelude::*;
 use std::io::{Error, ErrorKind};
 
+/// After sending a command, the read here is used to parse the response from our connection
+/// into the response enum.
 pub fn read<C>(read: C) -> Result<Response, Error>
 where
   C: std::io::Read + std::marker::Unpin,
 {
   let mut lines = std::io::BufReader::new(read).lines();
 
-  match readline(lines.next()) {
+  match lines
+    .next()
+    .ok_or_else(|| Error::new(ErrorKind::NotFound, "kramer: No lines available from reader."))
+    .and_then(|opt| opt.and_then(readline))
+  {
     Ok(ResponseLine::Array(size)) => {
       let mut store = Vec::with_capacity(size);
 
@@ -16,7 +22,16 @@ where
         return Ok(Response::Array(vec![]));
       }
 
-      while let Ok(kind) = readline(lines.next()) {
+      while let Ok(kind) = lines
+        .next()
+        .ok_or_else(|| {
+          Error::new(
+            ErrorKind::InvalidData,
+            "kramer: No lines avaible during array response parsing.",
+          )
+        })
+        .and_then(|opt| opt.and_then(readline))
+      {
         match kind {
           ResponseLine::BulkString(size) => match lines.next() {
             Some(Ok(bulky)) if bulky.len() == size => {
@@ -30,6 +45,11 @@ where
         if store.len() >= size {
           return Ok(Response::Array(store));
         }
+      }
+
+      if size != store.len() {
+        let message = format!("expected {} elements in response and received {}", size, store.len());
+        return Err(Error::new(ErrorKind::InvalidData, message));
       }
 
       Ok(Response::Array(store))
@@ -53,6 +73,7 @@ where
   }
 }
 
+/// Writes a command to the connection and will attempt to read a response.
 pub fn execute<C, S>(mut connection: C, message: S) -> Result<Response, Error>
 where
   S: std::fmt::Display,
@@ -62,6 +83,7 @@ where
   read(connection)
 }
 
+/// This method will attempt to establish a _new_ connection and execute the command.
 pub fn send<S>(addr: &str, message: S) -> Result<Response, Error>
 where
   S: std::fmt::Display,


### PR DESCRIPTION
hopefully improving error messages.
definitely adding clippy (and addressing problems).
improving ci release automation.

---

update: 8/30/2022 - I tracked this issue down to `lines.next().await` appearing to not return the `BrokenPipe` io error the same as manually iterating with several `read_line(...)` calls. Instead, a `None` value was coming back, making it difficult to determine if our connection was dropped. I'm not _exactly_ sure why that is happening, but given there is test coverage  targeting real redis servers in CI, this refactor is safe for the time being. 