### PR TITLE
acl command changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,11 @@ jobs:
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+      - name: test-sync-acl
+        run: cargo test --features acl
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
       - name: "clippy: acl"
         run: cargo clippy --features acl
       - name: "clippy: async"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kramer"
-version = "1.3.2"
+version = "2.0.0"
 authors = ["Danny Hadley <dadleyy@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/sync_io.rs
+++ b/src/sync_io.rs
@@ -81,7 +81,7 @@ where
   S: std::fmt::Display,
   C: std::io::Write + std::io::Read + std::marker::Unpin,
 {
-  write!(connection, "{}", message)?;
+  write!(connection, "{message}")?;
   read(connection)
 }
 


### PR DESCRIPTION
- use `vec` inside `SetUser` to support multiple commands.
- updating fomatting
- adding real integration-level tests for those commands


this is technically breaking, so we'll be going to `v2.0.0`