### PR TITLE
correcting the formatting of multiple commands in acl setuser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kramer"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Danny Hadley <dadleyy@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
- adds tests with multiple commands
- adds tests that expect failure