### PR TITLE
impl `async_std::io::Read` for `Command`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,7 @@ keywords = ["redis"]
 version = "^1.0"
 optional = true
 
-[dependencies.futures-io]
-version = "^0.3"
-optional = true
-
 [features]
 kramer-async = ["async-std"]
-kramer-async-read = ["futures-io", "kramer-async"]
+kramer-async-read = ["kramer-async"]
 acl = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kramer"
-version = "2.1.0"
+version = "3.0.0"
 authors = ["Danny Hadley <dadleyy@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -13,6 +13,11 @@ keywords = ["redis"]
 version = "^1.0"
 optional = true
 
+[dependencies.futures-io]
+version = "^0.3"
+optional = true
+
 [features]
 kramer-async = ["async-std"]
+kramer-async-read = ["futures-io", "kramer-async"]
 acl = []

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -16,10 +16,7 @@ use super::modifiers::{format_bulk_string, Arity};
 /// Notice: Currently `Display` is only implemented if all fields are present/`Some`.
 #[cfg(feature = "acl")]
 #[derive(Debug)]
-pub struct SetUser<S>
-where
-  S: std::fmt::Display,
-{
+pub struct SetUser<S> {
   /// The name of the ACL entry.
   pub name: S,
 
@@ -36,10 +33,7 @@ where
 /// Redis acl commands.
 #[cfg(feature = "acl")]
 #[derive(Debug)]
-pub enum AclCommand<S>
-where
-  S: std::fmt::Display,
-{
+pub enum AclCommand<S> {
   /// Requests a list of all acl entries.
   List,
 

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -3,11 +3,7 @@ use crate::modifiers::{format_bulk_string, Arity, Insertion};
 /// `HashCommand` represents the possible redis operations of keys that
 /// are a hash type.
 #[derive(Debug)]
-pub enum HashCommand<S, V>
-where
-  S: std::fmt::Display,
-  V: std::fmt::Display,
-{
+pub enum HashCommand<S, V> {
   /// Deletes fields from a given hash.
   Del(S, Arity<S>),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,11 +180,11 @@ where
 {
   /// This function mirrors the `execute` function provided in the `async_io` module, but uses the
   /// internally-available `AsyncRead` impl for our commands.
-  pub async fn execute<W>(&mut self, connection: &mut W) -> Result<Response, std::io::Error>
+  pub async fn execute<W>(&mut self, mut connection: W) -> Result<Response, std::io::Error>
   where
     W: async_std::io::Write + async_std::io::Read + std::marker::Unpin,
   {
-    async_std::io::copy(self, connection).await?;
+    async_std::io::copy(self, &mut connection).await?;
     read(connection).await
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,14 @@ where
       let header = header(content_size);
       for b in header.as_bytes() {
         if count >= outbound.len() {
-          return std::task::Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::Other, "")));
+          let err = std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+              "Unable to inject command 'header' into buffer at position {count} (of {})",
+              outbound.len()
+            ),
+          );
+          return std::task::Poll::Ready(Err(err));
         }
 
         outbound[count] = *b;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -2,11 +2,7 @@ use crate::modifiers::{format_bulk_string, Arity, Insertion, Side};
 
 /// Lists.
 #[derive(Debug)]
-pub enum ListCommand<S, V>
-where
-  S: std::fmt::Display,
-  V: std::fmt::Display,
-{
+pub enum ListCommand<S, V> {
   /// List length.
   Len(S),
 

--- a/src/sets.rs
+++ b/src/sets.rs
@@ -3,11 +3,7 @@ use crate::modifiers::{format_bulk_string, Arity};
 /// The `SetCommand` is used for working with redis keys that are sets: unique collections
 /// of values.
 #[derive(Debug)]
-pub enum SetCommand<S, V>
-where
-  S: std::fmt::Display,
-  V: std::fmt::Display,
-{
+pub enum SetCommand<S, V> {
   /// Adds a member(s) to a set.
   Add(S, Arity<V>),
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -3,11 +3,7 @@ use crate::modifiers::{format_bulk_string, Arity, Insertion};
 /// The `StringCommand` enum represents the most basic, key-value commands that
 /// redis offers; top-level keys with values being either strings or numbers.
 #[derive(Debug)]
-pub enum StringCommand<S, V>
-where
-  S: std::fmt::Display,
-  V: std::fmt::Display,
-{
+pub enum StringCommand<S, V> {
   /// Sets the value of a key.
   Set(Arity<(S, V)>, Option<std::time::Duration>, Insertion),
 


### PR DESCRIPTION
I'm not sure if this is awful practice, but it is pretty neat to be able to copy commands into a writer using `async_std::io::copy`:

```rust
let mut reader = Command::Strings(StringCommand::Set(
  Arity::One(("four", b"hi".into_iter().enumerate())),
  None,
  Insertion::Always,
));
async_std::io::copy(&mut reader, &mut stream).await.unwrap();
let res = read(&mut stream).await.expect("read response from redis");
assert_eq!(res, Response::Item(ResponseValue::String("OK".to_string())));
```

This also allows the library to support binary payloads, not just things that `impl std::fmt::Display`.